### PR TITLE
F421: work around bug in old bootloader

### DIFF
--- a/Mcu/f421/AT32F421x6_FLASH.ld
+++ b/Mcu/f421/AT32F421x6_FLASH.ld
@@ -20,8 +20,16 @@
 /* Entry Point */
 ENTRY(Reset_Handler)
 
-/* Highest address of the user mode stack */
-_estack = 0x20004000;    /* end of RAM */
+/*
+  Highest address of the user mode stack
+
+  we set this less than the 16k available due to a bug in the old
+  bootloader for F421. The old bootloader writes to the stack pointer
+  after setting up the stack based on the app header. This means if we
+  set the app stack right at the end of memory then the bootloader
+  hard faults.
+*/
+_estack = 0x20003c00;
 
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200;      /* required amount of heap  */
@@ -34,7 +42,7 @@ FLASH (rx)      : ORIGIN = 0x08001000, LENGTH = 27K
 FLASH_VERSION (rx)  : ORIGIN = 0x08007C00 - 48, LENGTH = 16
 FILE_NAME     (rx)  : ORIGIN = 0x08007C00 - 32, LENGTH = 32
 EEPROM        (rx)  : ORIGIN = 0x08007C00, LENGTH = 1K
-RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 16K
+RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 15K
 
 }
 


### PR DESCRIPTION
the released F421 bootloader that comes on F4A boards (at least for the holybro 4-in-1) does this:

```
   0x08000b3a:	ldr	r0, [r4, #24]
   0x08000b3c:	str	r0, [r4, #28]
   0x08000b3e:	ldr	r0, [r5, #0]
   0x08000b40:	msr	MSP, r0
   0x08000b44:	ldr	r0, [r4, #28]
   0x08000b46:	ldmia.w	sp!, {r4, r5, r7, lr}
   0x08000b4a:	bx	r0
```

that writes to the application stack area before jumping. If the application stack is set to the end of ram then the ldmia instruction hard faults as it writes past the end of memory

this avoids the issue by only giving the app 15k instead of 16k of ram. This is not needed when we fix the bootloader to use the right jump method, which is this:

    // setup sp, msp and jump
    asm volatile(
        "mov sp, %0	\n"
        "msr msp, %0	\n"
        "bx	%1	\n"
	: : "r"(stack_top), "r"(JumpAddress) :);

this issue is why the gcc generated F421 code didn't boot on F4A. The linker script for the gcc build puts the stack at the end of ram 0x20004000, whereas for some strange reason keil puts it at 0x20000e50

Note that the F421 bootloader currently in the download section of am32.ca has different jump code. It does this:
![image](https://github.com/user-attachments/assets/8e2d9068-4e17-44f9-af5d-594ba85c346c)
that does not write to the stack before the bx, so doesn't have the problem.
I'd guess the f421 bootloader was recompiled at some stage with different keil compiler or different compiler options?
