### PR TITLE
dshot: fixed timer wrap bug in DShot decode

### DIFF
--- a/Src/dshot.c
+++ b/Src/dshot.c
@@ -47,7 +47,10 @@ void computeDshotDMA()
     if ((dshot_frametime > dshot_frametime_low) && (dshot_frametime < dshot_frametime_high)) {
 			signaltimeout = 0;
         for (int i = 0; i < 16; i++) {
-            dpulse[i] = ((dma_buffer[(i << 1) + 1] - dma_buffer[(i << 1)]) > (halfpulsetime));
+            // note that dma_buffer[] is uint32_t, we cast the difference to uint16_t to handle
+            // timer wrap correctly
+            const uint16_t pdiff = dma_buffer[(i << 1) + 1] - dma_buffer[(i << 1)];
+            dpulse[i] = (pdiff > halfpulsetime);
         }
         uint8_t calcCRC = ((dpulse[0] ^ dpulse[4] ^ dpulse[8]) << 3 | (dpulse[1] ^ dpulse[5] ^ dpulse[9]) << 2 | (dpulse[2] ^ dpulse[6] ^ dpulse[10]) << 1 | (dpulse[3] ^ dpulse[7] ^ dpulse[11]));
         uint8_t checkCRC = (dpulse[12] << 3 | dpulse[13] << 2 | dpulse[14] << 1 | dpulse[15]);


### PR DESCRIPTION
when a 16 bit timer is being used for DShot capture wraps we get dma_buffer[] values that wrap back from 655xx to low values. The subtraction needs to be done as uint16_t to cope correctly with the wrap

this fixes a bug that caused dshot_badcount to tick over on each timer wrap where a DShot pulse was present
the screenshot below shows the dma_buffer[] in a debug session when the bug happens:
![image](https://github.com/user-attachments/assets/851aac3c-bd3c-4081-9d00-94b3a2f55479)
