### PR TITLE
add vimdrones esc nano target

### DIFF
--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -81,6 +81,17 @@
 #define EEPROM_START_ADD (uint32_t)0x0800F800
 #endif
 
+#ifdef VIMDRONES_NANO_L431
+#define FIRMWARE_NAME "VM_NANO"
+#define FILE_NAME "VIMDRONES_NANO_L431"
+#define DEAD_TIME 45
+#define HARDWARE_GROUP_L4_B
+#define TARGET_VOLTAGE_DIVIDER 110
+#define MILLIVOLT_PER_AMP 20
+#define USE_SERIAL_TELEMETRY
+#define EEPROM_START_ADD (uint32_t)0x0800F800
+#endif
+
 #ifdef  REF_L431
 #define FILE_NAME				"REF_L431"
 #define FIRMWARE_NAME           "L431 Neutron"


### PR DESCRIPTION
```
➜  AM32 git:(pr-add-vimdrones-esc-nano-target) ✗ make VIMDRONES_NANO_L431
Compiling AM32_VIMDRONES_NANO_L431_2.16.elf
Memory region         Used Size  Region Size  %age Used
             RAM:        3728 B        64 KB      5.69%
           FLASH:       23568 B        57 KB     40.38%
          EEPROM:          0 GB         2 KB      0.00%
   FLASH_VERSION:          0 GB         16 B      0.00%
       FILE_NAME:          32 B         32 B    100.00%
echo building BIN obj/AM32_VIMDRONES_NANO_L431_2.16.bin
building BIN obj/AM32_VIMDRONES_NANO_L431_2.16.bin
Generating AM32_VIMDRONES_NANO_L431_2.16.bin
```
twin version of vimdrones esc nano can, without can interface and HSE
board outline 12mm* 28mm
![vimdrones esc nano](https://github.com/user-attachments/assets/56f36817-9005-4d4e-9afd-ea89c986f7b8)

