### PR TITLE
Remove unused saveEEpromSettings from sounds.h

### DIFF
--- a/Inc/sounds.h
+++ b/Inc/sounds.h
@@ -19,7 +19,6 @@ void playDuskingTune(void);
 void playDefaultTone(void);
 void playChangedTone(void);
 
-void saveEEpromSettings(void);
 void setVolume(uint8_t volume);
 
 extern void delayMillis(uint32_t millis);

--- a/Mcu/f415/Inc/sounds.h
+++ b/Mcu/f415/Inc/sounds.h
@@ -19,7 +19,6 @@ void playDuskingTune(void);
 void playDefaultTone(void);
 void playChangedTone(void);
 
-void saveEEpromSettings(void);
 void setVolume(uint8_t volume);
 
 #endif /* SOUNDS_H_ */


### PR DESCRIPTION
These two definitions are unused. 