### PR TITLE
removed incorrect setting of eeprom_address

### DIFF
--- a/Src/main.c
+++ b/Src/main.c
@@ -1732,13 +1732,6 @@ int main(void)
 
     loadEEpromSettings();
 
- //   EEPROM_VERSION = *(uint8_t*)(0x08000FFC);
-
-	  if((*(uint32_t*)(0x08000FE0)) == 0xf8){
-			eeprom_address = (uint32_t)0x0800F800;
-		}
-
-	
     if (VERSION_MAJOR != eepromBuffer[3] || VERSION_MINOR != eepromBuffer[4]) {
         eepromBuffer[3] = VERSION_MAJOR;
         eepromBuffer[4] = VERSION_MINOR;


### PR DESCRIPTION
the address 0x08000FE0 does not have any special value in current bootloaders, so this just sets the eeprom_address address incorrectly based on a 1 in 256 chance
Note that this check could not be working anyway, as it comes after the call to loadEEpromSettings() which means we have already loaded our settings from the default address
