### PR TITLE
avoid reset of utility timer

### DIFF
--- a/Mcu/e230/Src/gd32e23x_it.c
+++ b/Mcu/e230/Src/gd32e23x_it.c
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 extern void transfercomplete();
 extern void PeriodElapsedCallback();
 extern void interruptRoutine();
@@ -14,7 +16,7 @@ extern char dshot_telemetry;
 extern char out_put;
 extern char armed;
 
-int interrupt_time = 0;
+uint16_t interrupt_time = 0;
 
 #include "gd32e23x_it.h"
 
@@ -129,7 +131,7 @@ void TIMER15_IRQHandler(void)
     interrupt_time = TIMER_CNT(UTILITY_TIMER);
     timer_interrupt_flag_clear(TIMER15, TIMER_INT_FLAG_UP);
     PeriodElapsedCallback();
-    interrupt_time = TIMER_CNT(UTILITY_TIMER) - interrupt_time;
+    interrupt_time = ((uint16_t)TIMER_CNT(UTILITY_TIMER)) - interrupt_time;
 }
 
 void TIMER14_IRQHandler(void) { timer_flag_clear(TIMER14, TIMER_FLAG_UP); }

--- a/Mcu/e230/Src/peripherals.c
+++ b/Mcu/e230/Src/peripherals.c
@@ -225,7 +225,7 @@ void TIMER16_Init(void)
 {
     rcu_periph_clock_enable(RCU_TIMER16);
     TIMER_CAR(TIMER16) = 0xFFFF;
-    TIMER_PSC(TIMER16) = 35;
+    TIMER_PSC(TIMER16) = 71;
     timer_auto_reload_shadow_enable(TIMER16);
     timer_enable(TIMER16);
 }

--- a/Mcu/f031/Src/stm32f0xx_it.c
+++ b/Mcu/f031/Src/stm32f0xx_it.c
@@ -65,7 +65,7 @@ extern char servoPwm;
 char input_ready = 0;
 int update_interupt = 0;
 uint8_t update_count = 0;
-int interrupt_time = 0;
+uint16_t interrupt_time = 0;
 /* USER CODE END PV */
 
 /* Private function prototypes
@@ -296,7 +296,7 @@ void TIM14_IRQHandler(void)
         interrupt_time = UTILITY_TIMER->CNT;
         PeriodElapsedCallback();
         LL_TIM_ClearFlag_UPDATE(TIM14);
-        interrupt_time = UTILITY_TIMER->CNT - interrupt_time;
+        interrupt_time = ((uint16_t)UTILITY_TIMER->CNT) - interrupt_time;
     }
     /* USER CODE END TIM14_IRQn 0 */
     /* USER CODE BEGIN TIM14_IRQn 1 */

--- a/Mcu/f051/Src/stm32f0xx_it.c
+++ b/Mcu/f051/Src/stm32f0xx_it.c
@@ -46,7 +46,7 @@ extern char out_put;
 extern char compute_dshot_flag;
 /* USER CODE END EV */
 
-int interrupt_time = 0;
+uint16_t interrupt_time = 0;
 /******************************************************************************/
 /*           Cortex-M0 Processor Interruption and Exception Handlers */
 /******************************************************************************/

--- a/Mcu/f415/Src/peripherals.c
+++ b/Mcu/f415/Src/peripherals.c
@@ -230,11 +230,14 @@ void TIM11_Init(void)
     NVIC_EnableIRQ(TMR1_TRG_HALL_TMR11_IRQn);
 }
 
+/*
+  16 bit 1MHz utility timer
+ */
 void TIM10_Init(void)
 {
     crm_periph_clock_enable(CRM_TMR10_PERIPH_CLOCK, TRUE);
     TMR10->pr = 0xFFFF;
-    TMR10->div = 75;
+    TMR10->div = 143;
     TMR10->ctrl1_bit.prben = TRUE;
 }
 

--- a/Mcu/f421/Src/peripherals.c
+++ b/Mcu/f421/Src/peripherals.c
@@ -187,7 +187,7 @@ void TIM17_Init(void)
 {
     crm_periph_clock_enable(CRM_TMR17_PERIPH_CLOCK, TRUE);
     TMR17->pr = 0xFFFF;
-    TMR17->div = 59;
+    TMR17->div = 119;
     TMR17->ctrl1_bit.prben = TRUE;
 
     // TMR_Cmd(TMR15, ENABLE);

--- a/Mcu/g071/Src/stm32g0xx_it.c
+++ b/Mcu/g071/Src/stm32g0xx_it.c
@@ -78,7 +78,7 @@ extern void tenKhzRoutine();
 extern void processDshot();
 
 extern char send_telemetry;
-int interrupt_time = 0;
+uint16_t interrupt_time = 0;
 extern char servoPwm;
 extern char dshot_telemetry;
 extern char armed;
@@ -324,7 +324,7 @@ void TIM14_IRQHandler(void)
     interrupt_time = UTILITY_TIMER->CNT;
     PeriodElapsedCallback();
     LL_TIM_ClearFlag_UPDATE(TIM14);
-    interrupt_time = UTILITY_TIMER->CNT - interrupt_time;
+    interrupt_time = ((uint16_t)UTILITY_TIMER->CNT) - interrupt_time;
 }
 
 /* USER CODE BEGIN 1 */

--- a/Mcu/g431/Src/peripherals.c
+++ b/Mcu/g431/Src/peripherals.c
@@ -384,7 +384,7 @@ void MX_TIM17_Init(void)
 {
     LL_TIM_InitTypeDef TIM_InitStruct = { 0 };
     LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_TIM17);
-    TIM_InitStruct.Prescaler = 149;
+    TIM_InitStruct.Prescaler = 159;
     TIM_InitStruct.CounterMode = LL_TIM_COUNTERMODE_UP;
     TIM_InitStruct.Autoreload = 65535;
     TIM_InitStruct.ClockDivision = LL_TIM_CLOCKDIVISION_DIV1;

--- a/Mcu/g431/Src/stm32g4xx_it.c
+++ b/Mcu/g431/Src/stm32g4xx_it.c
@@ -13,7 +13,7 @@ extern void tenKhzRoutine();
 extern void processDshot();
 
 extern char send_telemetry;
-int interrupt_time = 0;
+uint16_t interrupt_time = 0;
 extern char servoPwm;
 extern char dshot_telemetry;
 extern char armed;

--- a/Mcu/l431/Src/stm32l4xx_it.c
+++ b/Mcu/l431/Src/stm32l4xx_it.c
@@ -34,7 +34,7 @@ extern void tenKhzRoutine();
 extern void processDshot();
 
 extern char send_telemetry;
-int interrupt_time = 0;
+uint16_t interrupt_time = 0;
 extern char servoPwm;
 extern char dshot_telemetry;
 extern char armed;


### PR DESCRIPTION
This is broken out of the DroneCAN PR #36 

resetting the UTILITY_TIMER makes accurate long term time measurement  much harder. We never need to reset it if we treat it as a wrapping 16  bit unsigned number and always do timing maths with 16 bit subtraction
This means that separate parts of the code base can reliably make timing measurements as the UTILITY_TIMER is always incrementing and never reset. So we can get both timing measurements and absolute time in DroneCAN while still using the UTILITY_TIMER in other parts of the code.
It also saves a few bytes of flash, and simplifies the delay code in functions.c

todo:
 - [x] fix F421 TMR17 to be 1MHz
 - [x] check all MCUs have 1MHz UTILITY_TIMER
