### PR TITLE
DroneCAN: added software control of CAN termination

### DIFF
--- a/Inc/eeprom.h
+++ b/Inc/eeprom.h
@@ -57,7 +57,8 @@ typedef union EEprom_u {
             uint8_t require_zero_throttle; // 180
             uint8_t filter_hz; // 181
             uint8_t debug_rate; // 182
-            uint8_t reserved[9]; // 183-191
+            uint8_t term_enable; // 183
+            uint8_t reserved[8]; // 184-191
         } can;
     };
     uint8_t buffer[192];

--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -36,6 +36,9 @@
 // #define GD32SKYSTARS40
 #endif
 
+// used to hold a port/pin in a single 16 bit integer
+#define GPIO_PORT_PIN(portnum, pinnum) ((portnum)<<8|(pinnum))
+
 // GLOBAL
 // #define USE_ADC_INPUT
 // #define USE_ALKAS_DEBUG_LED
@@ -695,6 +698,8 @@
 #define HARDWARE_GROUP_AT_D
 #define HARDWARE_GROUP_AT_045
 #define DRONECAN_SUPPORT 1
+#define CAN_TERM_PIN GPIO_PORT_PIN(1, 3) // PB3
+#define CAN_TERM_POLARITY 1 // active high
 #define USE_SERIAL_TELEMETRY
 #define ADC_CHANNEL_VOLTAGE ADC_CHANNEL_6
 #define ADC_CHANNEL_CURRENT ADC_CHANNEL_3

--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -167,6 +167,9 @@ static const struct parameter {
         { "DRAG_BRAKE_STRENGTH",    T_UINT8, 1, 10,  10, &eepromBuffer.drag_brake_strength},
         { "INPUT_SIGNAL_TYPE",      T_UINT8, 0, 5,   5, &eepromBuffer.input_type},
         { "INPUT_FILTER_HZ",        T_UINT8, 0, 100, 0, &eepromBuffer.can.filter_hz},
+#ifdef CAN_TERM_PIN
+        { "CAN_TERM_ENABLE",        T_BOOL,  0, 1,   0, &eepromBuffer.can.term_enable},
+#endif
         { "STARTUP_TUNE",           T_STRING,0, 4,   0, &eepromBuffer.tune},
 };
 
@@ -994,6 +997,10 @@ static void process1HzTasks(uint64_t timestamp_usec)
       Transmit the node status message
     */
     send_NodeStatus();
+
+#ifdef CAN_TERM_PIN
+    setup_portpin(CAN_TERM_PIN, eepromBuffer.can.term_enable? CAN_TERM_POLARITY : !CAN_TERM_POLARITY);
+#endif
 }
 
 /*

--- a/Src/DroneCAN/sys_can.h
+++ b/Src/DroneCAN/sys_can.h
@@ -78,3 +78,6 @@ void set_rtc_backup_register(uint8_t idx, uint32_t value);
 #define RTC_BKUP0_FWUPDATE 0x42c7 // top byte is CAN node number, 2nd byte is file server node
 #define RTC_BKUP0_BOOTED 0x8c42c8 // set when main started
 #define RTC_BKUP0_SIGNAL 0x8c42c9 // set on 5 DroneCAN messages processed
+
+// setup a static port/pin
+void setup_portpin(uint16_t portpin, bool enable);

--- a/Src/DroneCAN/sys_can_at32.c
+++ b/Src/DroneCAN/sys_can_at32.c
@@ -253,5 +253,31 @@ void set_rtc_backup_register(uint8_t idx, uint32_t value)
     ertc_bpr_data_write(idx, value);
 }
 
+/*
+  setup a static port/pin
+ */
+void setup_portpin(uint16_t portpin, bool enable)
+{
+    const uint8_t port = portpin >> 8;
+    const uint8_t pin = portpin & 0xff;
+    const uint32_t pinshift = 1U<<pin;
+    gpio_type *pport = port==0?GPIOA:GPIOB;
+
+    if (enable) {
+        pport->scr = pinshift;
+    } else {
+        pport->clr = pinshift;
+    }
+    
+    gpio_init_type gpio_init_struct;
+
+    gpio_init_struct.gpio_drive_strength = GPIO_DRIVE_STRENGTH_STRONGER;
+    gpio_init_struct.gpio_out_type = GPIO_OUTPUT_PUSH_PULL;
+    gpio_init_struct.gpio_mode = GPIO_MODE_OUTPUT;
+    gpio_init_struct.gpio_pins = pinshift;
+    gpio_init_struct.gpio_pull = GPIO_PULL_NONE;
+    gpio_init(pport, &gpio_init_struct);
+}
+
 #endif // DRONECAN_SUPPORT && defined(ARTERY)
 

--- a/Src/DroneCAN/sys_can_stm32.c
+++ b/Src/DroneCAN/sys_can_stm32.c
@@ -239,5 +239,29 @@ void set_rtc_backup_register(uint8_t idx, uint32_t value)
     bkp[idx] = value;
 }
 
+/*
+  setup a static port/pin
+ */
+void setup_portpin(uint16_t portpin, bool enable)
+{
+    const uint8_t port = portpin >> 8;
+    const uint8_t pin = portpin & 0xff;
+    const uint32_t pinshift = 1U<<pin;
+    GPIO_TypeDef *pport = port==0?GPIOA:GPIOB;
+
+    if (enable) {
+        LL_GPIO_SetOutputPin(pport, pinshift);
+    } else {
+        LL_GPIO_ResetOutputPin(pport, pinshift);
+    }
+    
+    LL_GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitStruct.Pin = pinshift;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+    LL_GPIO_Init(pport, &GPIO_InitStruct);
+}
+
 #endif // DRONECAN_SUPPORT && defined(MCU_L431)
 


### PR DESCRIPTION
This allows for CAN_TERM_PIN and CAN_TERM_POLARITY in targets.h to give a GPIO which enables a termination resistor

Note that I have made setup_portpin() be CAN specific for now. I'd like to consider making it a standard API available for all MCUs in the future. It simplifies setting up of pins for things that are not timing critical, and makes it easier to specify a port+pin in targets.h
