### PR TITLE
added .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,33 @@
+# see https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,py}]
+charset = utf-8
+
+# 2 space indentation for C
+[*.{c,h}]
+indent_style = space
+indent_size = 2
+
+# 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4
+
+# Tab indentation for Makefile
+[Makefile]
+indent_style = tab
+indent_size = 8
+
+[*.mk]
+indent_style = tab
+indent_size = 8


### PR DESCRIPTION
this should make most editors use a consistent formatting convention, and also should make github PRs display patches with the same consistent indentation

See https://editorconfig.org/
