### PR TITLE
fixed g431 build

### DIFF
--- a/Mcu/e230/GD32E230K8_FLASH.ld
+++ b/Mcu/e230/GD32E230K8_FLASH.ld
@@ -12,7 +12,6 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 MEMORY
 {
 FLASH (rx)      : ORIGIN = 0x08001000, LENGTH = 27K
-FLASH_VERSION (rx)  : ORIGIN = 0x08007C00 - 48, LENGTH = 16
 FILE_NAME     (rx)  : ORIGIN = 0x08007C00 - 32, LENGTH = 32
 EEPROM        (rx)  : ORIGIN = 0x08007C00, LENGTH = 1K
 RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 16K
@@ -83,13 +82,6 @@ SECTIONS
     KEEP (*(.fini_array*))
     PROVIDE_HIDDEN (__fini_array_end = .);
   } >FLASH
-
-  .firmware_version :
-  {
-    . = ALIGN(4);
-	KEEP (*(.firmware_info))
-    . = ALIGN(4);
-  } >FLASH_VERSION
 
   /* The file name */
   .file_name :

--- a/Mcu/f031/STM32F031C6TX_FLASH.ld
+++ b/Mcu/f031/STM32F031C6TX_FLASH.ld
@@ -39,8 +39,7 @@ MEMORY
   SRAM          (xrw) : ORIGIN = 0x20000000, LENGTH = 192
   RAM           (xrw) : ORIGIN = 0x200000C0, LENGTH = 4K - 192
   FLASH_VECTAB  (rx)  : ORIGIN = 0x08001000, LENGTH = 192
-  FLASH_VERSION (rx)  : ORIGIN = 0x080010C0, LENGTH = 16
-  FLASH         (rx)  : ORIGIN = ORIGIN(FLASH_VERSION) + LENGTH(FLASH_VERSION), LENGTH = 27K - 32 -(LENGTH(FLASH_VECTAB) + LENGTH(FLASH_VERSION))
+  FLASH         (rx)  : ORIGIN = ORIGIN(FLASH_VECTAB) + LENGTH(FLASH_VECTAB), LENGTH = 27K - 32 - LENGTH(FLASH_VECTAB)
   FILE_NAME     (rx)  : ORIGIN = 0x08007C00 - 32, LENGTH = 32
   EEPROM        (rx)  : ORIGIN = 0x080007C00, LENGTH = 1K
  
@@ -56,16 +55,6 @@ SECTIONS
     KEEP(*(.isr_vector)) /* Startup code */
     . = ALIGN(4);
   } >FLASH_VECTAB
-  
-    /* The firmware version and name - at a fixed address to make it possible to read it from firmware files. */
-  .firmware_version :
-  {
-    . = ALIGN(4);
-	KEEP (*(.firmware_info))
-    . = ALIGN(4);
-  } >FLASH_VERSION
-  
-  
 
   /* The program code and other data into "FLASH" Rom type memory */
   .text :

--- a/Mcu/f051/STM32F051K6TX_FLASH.ld
+++ b/Mcu/f051/STM32F051K6TX_FLASH.ld
@@ -40,8 +40,7 @@ MEMORY
   SRAM          (xrw) : ORIGIN = 0x20000000, LENGTH = 192
   RAM           (xrw) : ORIGIN = 0x200000C0, LENGTH = 8K - 192
   FLASH_VECTAB  (rx)  : ORIGIN = 0x08001000, LENGTH = 192
-  FLASH_VERSION (rx)  : ORIGIN = 0x080010C0, LENGTH = 16
-  FLASH         (rx)  : ORIGIN = ORIGIN(FLASH_VERSION) + LENGTH(FLASH_VERSION), LENGTH = 27K - 32 - (LENGTH(FLASH_VECTAB) + LENGTH(FLASH_VERSION))
+  FLASH         (rx)  : ORIGIN = ORIGIN(FLASH_VECTAB) + LENGTH(FLASH_VECTAB), LENGTH = 27K - 32 - LENGTH(FLASH_VECTAB)
   FILE_NAME     (rx)  : ORIGIN = 0x08007C00 - 32, LENGTH = 32
   EEPROM        (rx)  : ORIGIN = 0x08007C00, LENGTH = 1K
 }
@@ -56,14 +55,6 @@ SECTIONS
     KEEP(*(.isr_vector)) /* Startup code */
     . = ALIGN(4);
   } >FLASH_VECTAB
-
-  /* The firmware version and name - at a fixed address to make it possible to read it from firmware files. */
-  .firmware_version :
-  {
-    . = ALIGN(4);
-	KEEP (*(.firmware_info))
-    . = ALIGN(4);
-  } >FLASH_VERSION
 
   /* The program code and other data into "FLASH" Rom type memory */
   .text :

--- a/Mcu/f415/ldscript.ld
+++ b/Mcu/f415/ldscript.ld
@@ -34,7 +34,6 @@ MEMORY
  RAM          (xrw)  : ORIGIN = 0x20000000, LENGTH = 16K
  FLASH         (rx)  : ORIGIN = 0x08001000, LENGTH = 57K
  EEPROM        (rx)  : ORIGIN = 0x0800f800, LENGTH = 2K
- FLASH_VERSION (rx)  : ORIGIN = ORIGIN(EEPROM) - 48, LENGTH = 16
  FILE_NAME     (rx)  : ORIGIN = ORIGIN(EEPROM) - 32, LENGTH = 32
 }
 
@@ -102,14 +101,6 @@ SECTIONS
     KEEP (*(.fini_array*))
     PROVIDE_HIDDEN (__fini_array_end = .);
   } >FLASH
-
-  .firmware_version :
-  {
-    . = ALIGN(4);
-	KEEP (*(.firmware_info))
-    . = ALIGN(4);
-  } >FLASH_VERSION
-
 
   /* The file name */
   .file_name :

--- a/Mcu/f421/AT32F421x6_FLASH.ld
+++ b/Mcu/f421/AT32F421x6_FLASH.ld
@@ -39,7 +39,6 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 MEMORY
 {
 FLASH (rx)      : ORIGIN = 0x08001000, LENGTH = 27K
-FLASH_VERSION (rx)  : ORIGIN = 0x08007C00 - 48, LENGTH = 16
 FILE_NAME     (rx)  : ORIGIN = 0x08007C00 - 32, LENGTH = 32
 EEPROM        (rx)  : ORIGIN = 0x08007C00, LENGTH = 1K
 RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 15K
@@ -110,13 +109,6 @@ SECTIONS
     KEEP (*(.fini_array*))
     PROVIDE_HIDDEN (__fini_array_end = .);
   } >FLASH
-
-  .firmware_version :
-  {
-    . = ALIGN(4);
-	KEEP (*(.firmware_info))
-    . = ALIGN(4);
-  } >FLASH_VERSION
 
   /* The file name */
   .file_name :

--- a/Mcu/g071/STM32G071GBUX_FLASH.ld
+++ b/Mcu/g071/STM32G071GBUX_FLASH.ld
@@ -41,8 +41,7 @@ MEMORY
 {
   RAM          (xrw) : ORIGIN = 0x20000000, LENGTH = 36K
   FLASH_VECTAB  (rx)  : ORIGIN = 0x08001000, LENGTH = 192
-  FLASH_VERSION (rx)  : ORIGIN = 0x080010C0, LENGTH = 16
-  FLASH         (rx)  : ORIGIN = ORIGIN(FLASH_VERSION) + LENGTH(FLASH_VERSION), LENGTH = 62K - 32 - (LENGTH(FLASH_VECTAB) + LENGTH(FLASH_VERSION))
+  FLASH         (rx)  : ORIGIN = ORIGIN(FLASH_VECTAB) + LENGTH(FLASH_VECTAB), LENGTH = 62K - 32 - LENGTH(FLASH_VECTAB)
   FILE_NAME     (rx)  : ORIGIN = 0x0800F800 - 32, LENGTH = 32
   EEPROM        (rx)  : ORIGIN = 0x0800F800, LENGTH = 2K
 }
@@ -57,14 +56,6 @@ SECTIONS
     KEEP(*(.isr_vector)) /* Startup code */
     . = ALIGN(4);
   } >FLASH_VECTAB
-
-  /* The firmware version and name - at a fixed address to make it possible to read it from firmware files. */
-  .firmware_version :
-  {
-    . = ALIGN(4);
-	KEEP (*(.firmware_info))
-    . = ALIGN(4);
-  } >FLASH_VERSION
 
   /* The program code and other data into "FLASH" Rom type memory */
   .text :

--- a/Mcu/g431/STM32G431_FLASH.ld
+++ b/Mcu/g431/STM32G431_FLASH.ld
@@ -14,9 +14,8 @@ _Min_Stack_Size = 0x400 ;	/* required amount of stack */
 MEMORY
 {
   RAM          (xrw) : ORIGIN = 0x20000000, LENGTH = 32K
-  FLASH_VECTAB  (rx)  : ORIGIN = 0x08001000, LENGTH = 192
-  FLASH_VERSION (rx)  : ORIGIN = 0x080010C0, LENGTH = 16
-  FLASH         (rx)  : ORIGIN = ORIGIN(FLASH_VERSION) + LENGTH(FLASH_VERSION), LENGTH = 62K - 32 - (LENGTH(FLASH_VECTAB) + LENGTH(FLASH_VERSION))
+  FLASH_VECTAB  (rx)  : ORIGIN = 0x08001000, LENGTH = 512
+  FLASH         (rx)  : ORIGIN = ORIGIN(FLASH_VECTAB) + LENGTH(FLASH_VECTAB), LENGTH = 62K - 32 - LENGTH(FLASH_VECTAB)
   FILE_NAME     (rx)  : ORIGIN = 0x0800F800 - 32, LENGTH = 32
   EEPROM        (rx)  : ORIGIN = 0x0800F800, LENGTH = 2K
 }
@@ -31,14 +30,6 @@ SECTIONS
     KEEP(*(.isr_vector)) /* Startup code */
     . = ALIGN(4);
   } >FLASH_VECTAB
-
-  /* The firmware version and name - at a fixed address to make it possible to read it from firmware files. */
-  .firmware_version :
-  {
-    . = ALIGN(4);
-	KEEP (*(.firmware_info))
-    . = ALIGN(4);
-  } >FLASH_VERSION
 
   /* The program code and other data into "FLASH" Rom type memory */
   .text :

--- a/Mcu/g431/Startup/gcc/startup_stm32g431xx.s
+++ b/Mcu/g431/Startup/gcc/startup_stm32g431xx.s
@@ -1,0 +1,498 @@
+/**
+  ******************************************************************************
+  * @file      startup_stm32g431xx.s
+  * @author    MCD Application Team
+  * @brief     STM32G431xx devices vector table GCC toolchain.
+  *            This module performs:
+  *                - Set the initial SP
+  *                - Set the initial PC == Reset_Handler,
+  *                - Set the vector table entries with the exceptions ISR address,
+  *                - Configure the clock system
+  *                - Branches to main in the C library (which eventually
+  *                  calls main()).
+  *            After Reset the Cortex-M4 processor is in Thread mode,
+  *            priority is Privileged, and the Stack is set to Main.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+  .syntax unified
+	.cpu cortex-m4
+	.fpu softvfp
+	.thumb
+
+.global	g_pfnVectors
+.global	Default_Handler
+
+/* start address for the initialization values of the .data section.
+defined in linker script */
+.word	_sidata
+/* start address for the .data section. defined in linker script */
+.word	_sdata
+/* end address for the .data section. defined in linker script */
+.word	_edata
+/* start address for the .bss section. defined in linker script */
+.word	_sbss
+/* end address for the .bss section. defined in linker script */
+.word	_ebss
+
+.equ  BootRAM,        0xF1E0F85F
+/**
+ * @brief  This is the code that gets called when the processor first
+ *          starts execution following a reset event. Only the absolutely
+ *          necessary set is performed, after which the application
+ *          supplied main() routine is called.
+ * @param  None
+ * @retval : None
+*/
+
+    .section	.text.Reset_Handler
+	.weak	Reset_Handler
+	.type	Reset_Handler, %function
+Reset_Handler:
+  ldr   r0, =_estack
+  mov   sp, r0          /* set stack pointer */
+  
+/* Call the clock system initialization function.*/
+    bl  SystemInit
+
+/* Copy the data segment initializers from flash to SRAM */
+  ldr r0, =_sdata
+  ldr r1, =_edata
+  ldr r2, =_sidata
+  movs r3, #0
+  b	LoopCopyDataInit
+
+CopyDataInit:
+  ldr r4, [r2, r3]
+  str r4, [r0, r3]
+  adds r3, r3, #4
+
+LoopCopyDataInit:
+  adds r4, r0, r3
+  cmp r4, r1
+  bcc CopyDataInit
+  
+/* Zero fill the bss segment. */
+  ldr r2, =_sbss
+  ldr r4, =_ebss
+  movs r3, #0
+  b LoopFillZerobss
+
+FillZerobss:
+  str  r3, [r2]
+  adds r2, r2, #4
+
+LoopFillZerobss:
+  cmp r2, r4
+  bcc FillZerobss
+/* Call static constructors */
+    bl __libc_init_array
+/* Call the application's entry point.*/
+	bl	main
+
+LoopForever:
+    b LoopForever
+
+.size	Reset_Handler, .-Reset_Handler
+
+/**
+ * @brief  This is the code that gets called when the processor receives an
+ *         unexpected interrupt.  This simply enters an infinite loop, preserving
+ *         the system state for examination by a debugger.
+ *
+ * @param  None
+ * @retval : None
+*/
+    .section	.text.Default_Handler,"ax",%progbits
+Default_Handler:
+Infinite_Loop:
+	b	Infinite_Loop
+	.size	Default_Handler, .-Default_Handler
+/******************************************************************************
+*
+* The minimal vector table for a Cortex-M4.  Note that the proper constructs
+* must be placed on this to ensure that it ends up at physical address
+* 0x0000.0000.
+*
+******************************************************************************/
+ 	.section	.isr_vector,"a",%progbits
+	.type	g_pfnVectors, %object
+
+
+g_pfnVectors:
+	.word	_estack
+	.word	Reset_Handler
+	.word	NMI_Handler
+	.word	HardFault_Handler
+	.word	MemManage_Handler
+	.word	BusFault_Handler
+	.word	UsageFault_Handler
+	.word	0
+	.word	0
+	.word	0
+	.word	0
+	.word	SVC_Handler
+	.word	DebugMon_Handler
+	.word	0
+	.word	PendSV_Handler
+	.word	SysTick_Handler
+	.word	WWDG_IRQHandler
+	.word	PVD_PVM_IRQHandler
+	.word	RTC_TAMP_LSECSS_IRQHandler
+	.word	RTC_WKUP_IRQHandler
+	.word	FLASH_IRQHandler
+	.word	RCC_IRQHandler
+	.word	EXTI0_IRQHandler
+	.word	EXTI1_IRQHandler
+	.word	EXTI2_IRQHandler
+	.word	EXTI3_IRQHandler
+	.word	EXTI4_IRQHandler
+	.word	DMA1_Channel1_IRQHandler
+	.word	DMA1_Channel2_IRQHandler
+	.word	DMA1_Channel3_IRQHandler
+	.word	DMA1_Channel4_IRQHandler
+	.word	DMA1_Channel5_IRQHandler
+	.word	DMA1_Channel6_IRQHandler
+	.word	0
+	.word	ADC1_2_IRQHandler
+	.word	USB_HP_IRQHandler
+	.word	USB_LP_IRQHandler
+	.word	FDCAN1_IT0_IRQHandler
+	.word	FDCAN1_IT1_IRQHandler
+	.word	EXTI9_5_IRQHandler
+	.word	TIM1_BRK_TIM15_IRQHandler
+	.word	TIM1_UP_TIM16_IRQHandler
+	.word	TIM1_TRG_COM_TIM17_IRQHandler
+	.word	TIM1_CC_IRQHandler
+	.word	TIM2_IRQHandler
+	.word	TIM3_IRQHandler
+	.word	TIM4_IRQHandler
+	.word	I2C1_EV_IRQHandler
+	.word	I2C1_ER_IRQHandler
+	.word	I2C2_EV_IRQHandler
+	.word	I2C2_ER_IRQHandler
+	.word	SPI1_IRQHandler
+	.word	SPI2_IRQHandler
+	.word	USART1_IRQHandler
+	.word	USART2_IRQHandler
+	.word	USART3_IRQHandler
+	.word	EXTI15_10_IRQHandler
+	.word	RTC_Alarm_IRQHandler
+	.word	USBWakeUp_IRQHandler
+	.word	TIM8_BRK_IRQHandler
+	.word	TIM8_UP_IRQHandler
+	.word	TIM8_TRG_COM_IRQHandler
+	.word	TIM8_CC_IRQHandler
+	.word	0
+	.word	0
+	.word	LPTIM1_IRQHandler
+	.word	0
+	.word	SPI3_IRQHandler
+	.word	UART4_IRQHandler
+	.word	0
+	.word	TIM6_DAC_IRQHandler
+	.word	TIM7_IRQHandler
+	.word	DMA2_Channel1_IRQHandler
+	.word	DMA2_Channel2_IRQHandler
+	.word	DMA2_Channel3_IRQHandler
+	.word	DMA2_Channel4_IRQHandler
+	.word	DMA2_Channel5_IRQHandler
+	.word	0
+	.word	0
+	.word	UCPD1_IRQHandler
+	.word	COMP1_2_3_IRQHandler
+	.word	COMP4_IRQHandler
+	.word	0
+	.word	0
+	.word	0
+	.word	0
+	.word	0
+	.word	0
+	.word	0
+	.word	0
+	.word	0
+	.word	CRS_IRQHandler
+	.word	SAI1_IRQHandler
+	.word	0
+	.word	0
+	.word	0
+	.word	0
+	.word	FPU_IRQHandler
+	.word	0
+	.word	0
+	.word	0
+	.word	0
+	.word	0
+	.word	0
+	.word	0
+	.word	0
+	.word	RNG_IRQHandler
+	.word	LPUART1_IRQHandler
+	.word	I2C3_EV_IRQHandler
+	.word	I2C3_ER_IRQHandler
+	.word	DMAMUX_OVR_IRQHandler
+	.word	0
+	.word	0
+	.word	DMA2_Channel6_IRQHandler
+	.word	0
+	.word	0
+	.word	CORDIC_IRQHandler
+	.word	FMAC_IRQHandler
+
+	.size	g_pfnVectors, .-g_pfnVectors
+
+/*******************************************************************************
+*
+* Provide weak aliases for each Exception handler to the Default_Handler.
+* As they are weak aliases, any function with the same name will override
+* this definition.
+*
+*******************************************************************************/
+
+	.weak	NMI_Handler
+	.thumb_set NMI_Handler,Default_Handler
+
+	.weak	HardFault_Handler
+	.thumb_set HardFault_Handler,Default_Handler
+
+	.weak	MemManage_Handler
+	.thumb_set MemManage_Handler,Default_Handler
+
+	.weak	BusFault_Handler
+	.thumb_set BusFault_Handler,Default_Handler
+
+	.weak	UsageFault_Handler
+	.thumb_set UsageFault_Handler,Default_Handler
+
+	.weak	SVC_Handler
+	.thumb_set SVC_Handler,Default_Handler
+
+	.weak	DebugMon_Handler
+	.thumb_set DebugMon_Handler,Default_Handler
+
+	.weak	PendSV_Handler
+	.thumb_set PendSV_Handler,Default_Handler
+
+	.weak	SysTick_Handler
+	.thumb_set SysTick_Handler,Default_Handler
+
+	.weak	WWDG_IRQHandler
+	.thumb_set WWDG_IRQHandler,Default_Handler
+
+	.weak	PVD_PVM_IRQHandler
+	.thumb_set PVD_PVM_IRQHandler,Default_Handler
+
+	.weak	RTC_TAMP_LSECSS_IRQHandler
+	.thumb_set RTC_TAMP_LSECSS_IRQHandler,Default_Handler
+
+	.weak	RTC_WKUP_IRQHandler
+	.thumb_set RTC_WKUP_IRQHandler,Default_Handler
+
+	.weak	FLASH_IRQHandler
+	.thumb_set FLASH_IRQHandler,Default_Handler
+
+	.weak	RCC_IRQHandler
+	.thumb_set RCC_IRQHandler,Default_Handler
+
+	.weak	EXTI0_IRQHandler
+	.thumb_set EXTI0_IRQHandler,Default_Handler
+
+	.weak	EXTI1_IRQHandler
+	.thumb_set EXTI1_IRQHandler,Default_Handler
+
+	.weak	EXTI2_IRQHandler
+	.thumb_set EXTI2_IRQHandler,Default_Handler
+
+	.weak	EXTI3_IRQHandler
+	.thumb_set EXTI3_IRQHandler,Default_Handler
+
+	.weak	EXTI4_IRQHandler
+	.thumb_set EXTI4_IRQHandler,Default_Handler
+
+	.weak	DMA1_Channel1_IRQHandler
+	.thumb_set DMA1_Channel1_IRQHandler,Default_Handler
+
+	.weak	DMA1_Channel2_IRQHandler
+	.thumb_set DMA1_Channel2_IRQHandler,Default_Handler
+
+	.weak	DMA1_Channel3_IRQHandler
+	.thumb_set DMA1_Channel3_IRQHandler,Default_Handler
+
+	.weak	DMA1_Channel4_IRQHandler
+	.thumb_set DMA1_Channel4_IRQHandler,Default_Handler
+
+	.weak	DMA1_Channel5_IRQHandler
+	.thumb_set DMA1_Channel5_IRQHandler,Default_Handler
+
+	.weak	DMA1_Channel6_IRQHandler
+	.thumb_set DMA1_Channel6_IRQHandler,Default_Handler
+
+	.weak	ADC1_2_IRQHandler
+	.thumb_set ADC1_2_IRQHandler,Default_Handler
+
+	.weak	USB_HP_IRQHandler
+	.thumb_set USB_HP_IRQHandler,Default_Handler
+
+	.weak	USB_LP_IRQHandler
+	.thumb_set USB_LP_IRQHandler,Default_Handler
+
+	.weak	FDCAN1_IT0_IRQHandler
+	.thumb_set FDCAN1_IT0_IRQHandler,Default_Handler
+
+	.weak	FDCAN1_IT1_IRQHandler
+	.thumb_set FDCAN1_IT1_IRQHandler,Default_Handler
+
+	.weak	EXTI9_5_IRQHandler
+	.thumb_set EXTI9_5_IRQHandler,Default_Handler
+
+	.weak	TIM1_BRK_TIM15_IRQHandler
+	.thumb_set TIM1_BRK_TIM15_IRQHandler,Default_Handler
+
+	.weak	TIM1_UP_TIM16_IRQHandler
+	.thumb_set TIM1_UP_TIM16_IRQHandler,Default_Handler
+
+	.weak	TIM1_TRG_COM_TIM17_IRQHandler
+	.thumb_set TIM1_TRG_COM_TIM17_IRQHandler,Default_Handler
+
+	.weak	TIM1_CC_IRQHandler
+	.thumb_set TIM1_CC_IRQHandler,Default_Handler
+
+	.weak	TIM2_IRQHandler
+	.thumb_set TIM2_IRQHandler,Default_Handler
+
+	.weak	TIM3_IRQHandler
+	.thumb_set TIM3_IRQHandler,Default_Handler
+
+	.weak	TIM4_IRQHandler
+	.thumb_set TIM4_IRQHandler,Default_Handler
+
+	.weak	I2C1_EV_IRQHandler
+	.thumb_set I2C1_EV_IRQHandler,Default_Handler
+
+	.weak	I2C1_ER_IRQHandler
+	.thumb_set I2C1_ER_IRQHandler,Default_Handler
+
+	.weak	I2C2_EV_IRQHandler
+	.thumb_set I2C2_EV_IRQHandler,Default_Handler
+
+	.weak	I2C2_ER_IRQHandler
+	.thumb_set I2C2_ER_IRQHandler,Default_Handler
+
+	.weak	SPI1_IRQHandler
+	.thumb_set SPI1_IRQHandler,Default_Handler
+
+	.weak	SPI2_IRQHandler
+	.thumb_set SPI2_IRQHandler,Default_Handler
+
+	.weak	USART1_IRQHandler
+	.thumb_set USART1_IRQHandler,Default_Handler
+
+	.weak	USART2_IRQHandler
+	.thumb_set USART2_IRQHandler,Default_Handler
+
+	.weak	USART3_IRQHandler
+	.thumb_set USART3_IRQHandler,Default_Handler
+
+	.weak	EXTI15_10_IRQHandler
+	.thumb_set EXTI15_10_IRQHandler,Default_Handler
+
+	.weak	RTC_Alarm_IRQHandler
+	.thumb_set RTC_Alarm_IRQHandler,Default_Handler
+
+	.weak	USBWakeUp_IRQHandler
+	.thumb_set USBWakeUp_IRQHandler,Default_Handler
+
+	.weak	TIM8_BRK_IRQHandler
+	.thumb_set TIM8_BRK_IRQHandler,Default_Handler
+
+	.weak	TIM8_UP_IRQHandler
+	.thumb_set TIM8_UP_IRQHandler,Default_Handler
+
+	.weak	TIM8_TRG_COM_IRQHandler
+	.thumb_set TIM8_TRG_COM_IRQHandler,Default_Handler
+
+	.weak	TIM8_CC_IRQHandler
+	.thumb_set TIM8_CC_IRQHandler,Default_Handler
+
+	.weak	LPTIM1_IRQHandler
+	.thumb_set LPTIM1_IRQHandler,Default_Handler
+
+	.weak	SPI3_IRQHandler
+	.thumb_set SPI3_IRQHandler,Default_Handler
+
+	.weak	UART4_IRQHandler
+	.thumb_set UART4_IRQHandler,Default_Handler
+
+	.weak	TIM6_DAC_IRQHandler
+	.thumb_set TIM6_DAC_IRQHandler,Default_Handler
+
+	.weak	TIM7_IRQHandler
+	.thumb_set TIM7_IRQHandler,Default_Handler
+
+	.weak	DMA2_Channel1_IRQHandler
+	.thumb_set DMA2_Channel1_IRQHandler,Default_Handler
+
+	.weak	DMA2_Channel2_IRQHandler
+	.thumb_set DMA2_Channel2_IRQHandler,Default_Handler
+
+	.weak	DMA2_Channel3_IRQHandler
+	.thumb_set DMA2_Channel3_IRQHandler,Default_Handler
+
+	.weak	DMA2_Channel4_IRQHandler
+	.thumb_set DMA2_Channel4_IRQHandler,Default_Handler
+
+	.weak	DMA2_Channel5_IRQHandler
+	.thumb_set DMA2_Channel5_IRQHandler,Default_Handler
+
+	.weak	UCPD1_IRQHandler
+	.thumb_set UCPD1_IRQHandler,Default_Handler
+
+	.weak	COMP1_2_3_IRQHandler
+	.thumb_set COMP1_2_3_IRQHandler,Default_Handler
+
+	.weak	COMP4_IRQHandler
+	.thumb_set COMP4_IRQHandler,Default_Handler
+
+	.weak	CRS_IRQHandler
+	.thumb_set CRS_IRQHandler,Default_Handler
+
+	.weak	SAI1_IRQHandler
+	.thumb_set SAI1_IRQHandler,Default_Handler
+
+	.weak	FPU_IRQHandler
+	.thumb_set FPU_IRQHandler,Default_Handler
+
+	.weak	RNG_IRQHandler
+	.thumb_set RNG_IRQHandler,Default_Handler
+
+	.weak	LPUART1_IRQHandler
+	.thumb_set LPUART1_IRQHandler,Default_Handler
+
+	.weak	I2C3_EV_IRQHandler
+	.thumb_set I2C3_EV_IRQHandler,Default_Handler
+
+	.weak	I2C3_ER_IRQHandler
+	.thumb_set I2C3_ER_IRQHandler,Default_Handler
+
+	.weak	DMAMUX_OVR_IRQHandler
+	.thumb_set DMAMUX_OVR_IRQHandler,Default_Handler
+
+	.weak	DMA2_Channel6_IRQHandler
+	.thumb_set DMA2_Channel6_IRQHandler,Default_Handler
+
+	.weak	CORDIC_IRQHandler
+	.thumb_set CORDIC_IRQHandler,Default_Handler
+
+	.weak	FMAC_IRQHandler
+	.thumb_set FMAC_IRQHandler,Default_Handler
+

--- a/Mcu/l431/ldscript.ld
+++ b/Mcu/l431/ldscript.ld
@@ -48,7 +48,6 @@ MEMORY
  RAM          (xrw)  : ORIGIN = 0x20000000, LENGTH = 64K
  FLASH         (rx)  : ORIGIN = 0x08001000, LENGTH = 57K
  EEPROM        (rx)  : ORIGIN = 0x0800f800, LENGTH = 2K
- FLASH_VERSION (rx)  : ORIGIN = ORIGIN(EEPROM) - 48, LENGTH = 16
  FILE_NAME     (rx)  : ORIGIN = ORIGIN(EEPROM) - 32, LENGTH = 32
 }
 
@@ -131,13 +130,6 @@ SECTIONS
     PROVIDE_HIDDEN (__fini_array_end = .);
     . = ALIGN(4);
   } >FLASH
-
-  .firmware_version :
-  {
-    . = ALIGN(4);
-	KEEP (*(.firmware_info))
-    . = ALIGN(4);
-  } >FLASH_VERSION
 
   /* The file name */
   .file_name :

--- a/STM32F051K6TX_FLASH.ld
+++ b/STM32F051K6TX_FLASH.ld
@@ -40,8 +40,7 @@ MEMORY
   SRAM          (xrw) : ORIGIN = 0x20000000, LENGTH = 192
   RAM           (xrw) : ORIGIN = 0x200000C0, LENGTH = 8K - 192
   FLASH_VECTAB  (rx)  : ORIGIN = 0x08001000, LENGTH = 192
-  FLASH_VERSION (rx)  : ORIGIN = 0x080010C0, LENGTH = 14
-  FLASH         (rx)  : ORIGIN = ORIGIN(FLASH_VERSION) + LENGTH(FLASH_VERSION), LENGTH = 27K - (LENGTH(FLASH_VECTAB) + LENGTH(FLASH_VERSION))
+  FLASH         (rx)  : ORIGIN = ORIGIN(FLASH_VECTAB) + LENGTH(FLASH_VECTAB), LENGTH = 27K - LENGTH(FLASH_VECTAB)
   EEPROM        (rx)  : ORIGIN = 0x080007C00, LENGTH = 1K
 }
 
@@ -55,13 +54,6 @@ SECTIONS
     KEEP(*(.isr_vector)) /* Startup code */
     . = ALIGN(4);
   } >FLASH_VECTAB
-
-  /* The firmware version and name - at a fixed address to make it possible to read it from firmware files. */
-  .firmware_version :
-  {
-    . = ALIGN(4);
-	KEEP (*(.firmware_info))
-  } >FLASH_VERSION
 
   /* The program code and other data into "FLASH" Rom type memory */
   .text :

--- a/Src/main.c
+++ b/Src/main.c
@@ -1619,20 +1619,6 @@ int main(void)
 
     loadEEpromSettings();
 
-#ifdef USE_MAKE
-    if (
-        firmware_info.version_major != eepromBuffer.version.major ||
-        firmware_info.version_minor != eepromBuffer.version.minor ||
-        eeprom_layout_version > eepromBuffer.eeprom_version
-    ) {
-        eepromBuffer.version.major = firmware_info.version_major;
-        eepromBuffer.version.minor = firmware_info.version_minor;
-        for (int i = 0; i < 12; i++) {
-            eepromBuffer.firmware_name[i] = firmware_info.device_name[i];
-        }
-        saveEEpromSettings();
-    }
-#else
     if (VERSION_MAJOR != eepromBuffer.version.major || VERSION_MINOR != eepromBuffer.version.minor || eeprom_layout_version > eepromBuffer.eeprom_version) {
         eepromBuffer.version.major = VERSION_MAJOR;
         eepromBuffer.version.minor = VERSION_MINOR;
@@ -1641,7 +1627,7 @@ int main(void)
         }
         saveEEpromSettings();
     }
-#endif
+
     // if (eepromBuffer.use_sine_start) {
         //    min_startup_duty = sin_mode_min_s_d;
     // }


### PR DESCRIPTION
The g431 build was missing the gcc specific startup file, I had it locally when I tested but forgot to add back when I added g431 makefile support. Unfortunately the compiler only throws a warning when Reset_Handler is missing at the link stage, not an error, so it didn't show up in CI testing
I also had to fix the linker script for g431 to have more space in the FLASH_VECTAB region as it overflowed, and while fixing that I had to remove the FLASH_VERSION section, which is unused. The old USE_MAKE code in main used firmware_info which used this section, but that isn't used any more since we went to the new Makefile system. The USE_MAKE changes had been resurrected by a bad rebase of the eeprom PR.
To clean things up this PR removes all of the FLASH_VERSION sections in the linker script, which are unused.
