### PR TITLE
fix play custom tone condition error

### DIFF
--- a/Src/sounds.c
+++ b/Src/sounds.c
@@ -93,8 +93,7 @@ void playStartupTune()
 {
     __disable_irq();
 
-    uint8_t value = *(uint8_t*)(eeprom_address + 48);
-    if (value != 0xFF) {
+    if (eepromBuffer.tune[0] != 0xFF) {
         playBlueJayTune();
     } else {
         SET_AUTO_RELOAD_PWM(TIM1_AUTORELOAD);


### PR DESCRIPTION
after the eeprom struct update, play custom tone is broken, index 48 is reserved_2 cause online configuror still pack byte to this position so normal firmware is still playing custom tone, but dronecan version is broken
https://github.com/am32-firmware/AM32/blob/main/Src/sounds.c#L64
![11161733382165_ pic](https://github.com/user-attachments/assets/677222a8-8f0b-4c9e-b6bd-879d14d51618)
