### PR TITLE
fix tune len back to 128

### DIFF
--- a/Inc/eeprom.h
+++ b/Inc/eeprom.h
@@ -47,8 +47,7 @@ typedef union EEprom_u {
         uint8_t sine_mode_power; // 45
         uint8_t input_type; // 46
         uint8_t auto_advance; // 47
-        uint8_t reserved_2[4]; //48-51
-        uint8_t tune[124]; // 52-175
+        uint8_t tune[128]; // 48-175
         struct {
             uint8_t can_node; // 176
             uint8_t esc_index; // 177

--- a/Src/sounds.c
+++ b/Src/sounds.c
@@ -62,7 +62,8 @@ void playBlueJayTune()
     uint16_t frequency;
     comStep(3);
     // read_flash_bin(blueJayTuneBuffer , eeprom_address + 48 , 128);
-    for (int i = 0; i < 124; i += 2) {
+    // first 4 bytes are reserved for rtttl duration, octave, beat, tempo
+    for (int i = 4; i < 128; i += 2) {
         RELOAD_WATCHDOG_COUNTER();
         signaltimeout = 0;
 


### PR DESCRIPTION
Original first 4 bytes is storing the RTTTL head which is not used
Tested on Vimdrones L431 dev board, both VIMDRONES_L431 and VIMDRONES_L431_CAN 
use size_t and sizeof for the tune array indexing, this won't increase the firmware size