### PR TITLE
DShot timing improvements, L431 HSI

### DIFF
--- a/Mcu/l431/Src/IO.c
+++ b/Mcu/l431/Src/IO.c
@@ -68,7 +68,7 @@ void sendDshotDma()
     IC_TIMER_REGISTER->CCMR1 = 0x60;
     IC_TIMER_REGISTER->CCER = 0x3;
     IC_TIMER_REGISTER->PSC = output_timer_prescaler;
-    IC_TIMER_REGISTER->ARR = 115;
+    IC_TIMER_REGISTER->ARR = 110;
 
     IC_TIMER_REGISTER->EGR |= TIM_EGR_UG;
 #ifdef USE_TIMER_3_CHANNEL_1

--- a/Mcu/l431/Src/peripherals.c
+++ b/Mcu/l431/Src/peripherals.c
@@ -73,17 +73,15 @@ void SystemClock_Config(void)
 #endif
 
 #else
-  LL_RCC_MSI_Enable();
+  LL_RCC_HSI_Enable();
 
-   /* Wait till MSI is ready */
-  while(LL_RCC_MSI_IsReady() != 1)
+   /* Wait till HSI is ready */
+  while(LL_RCC_HSI_IsReady() != 1)
   {
 
   }
-  LL_RCC_MSI_EnableRangeSelection();
-  LL_RCC_MSI_SetRange(LL_RCC_MSIRANGE_6);
-  LL_RCC_MSI_SetCalibTrimming(0);
-  LL_RCC_PLL_ConfigDomain_SYS(LL_RCC_PLLSOURCE_MSI, LL_RCC_PLLM_DIV_1, 40, LL_RCC_PLLR_DIV_2);
+  LL_RCC_HSI_SetCalibTrimming(16);
+  LL_RCC_PLL_ConfigDomain_SYS(LL_RCC_PLLSOURCE_HSI, LL_RCC_PLLM_DIV_1, 10, LL_RCC_PLLR_DIV_2);
 #endif
 
   LL_RCC_PLL_EnableDomain_SYS();


### PR DESCRIPTION
I observed that the DShot telemetry responses of L431 are sometimes not picked up correctly by betaflight due to 2 reasons:

- the ARR timer config was not entirely correct -->  Dhshot telemetry is transmitted at 5/4 the bitrate of tha command, so for DShot 300 this is 375kBit/s --> 2.75us/bitTimer running @40MHz 2.75e-6s*40MHz = 110
- the MSI caused siginficant temperature drift, so I switched to HSI

That's the MSI drifting when heated up witrh a heatgun:
https://github.com/user-attachments/assets/b4a752c0-762f-486b-9145-2abaf7c73def

This is wich HSI:
https://github.com/user-attachments/assets/8c232ff9-8f6b-4ace-a406-ba07d1ed5a5e

This also aligns well with this PR in the bootloader: https://github.com/am32-firmware/AM32-bootloader/pull/35

