### PR TITLE
fix dronecan bidirection input range

### DIFF
--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -629,9 +629,9 @@ static void handle_RawCommand(CanardInstance *ins, CanardRxTransfer *transfer)
     } else if (eepromBuffer.bi_direction) {
         const float scaled_value = input_can * (1000.0 / 8192);
         if (scaled_value >= 0) {
-            this_input = (uint16_t)(47 + scaled_value);
+            this_input = (uint16_t)(1047 + scaled_value);
         } else {
-            this_input = (uint16_t)(47 + (1000 - scaled_value));
+            this_input = (uint16_t)(47 + scaled_value * -1);
         }
     } else if (input_can > 0) {
         const float scaled_value = input_can * (2000.0 / 8192);


### PR DESCRIPTION
Fix a bug found on dronecan firmware, when set bidirection to true, original forwared changed, fix using high side range as forware, low side as reverse