### PR TITLE
F051 serial telemetry improvements:

### DIFF
--- a/Mcu/f051/Src/serial_telemetry.c
+++ b/Mcu/f051/Src/serial_telemetry.c
@@ -48,7 +48,7 @@ void telem_UART_Init(void)
     LL_DMA_SetPeriphSize(DMA1, LL_DMA_CHANNEL_4, LL_DMA_PDATAALIGN_BYTE);
     LL_DMA_SetMemorySize(DMA1, LL_DMA_CHANNEL_4, LL_DMA_MDATAALIGN_BYTE);
 
-    /* USART1 interrupt Init */
+    /* USART2 interrupt Init */
     NVIC_SetPriority(USART2_IRQn, 3);
     NVIC_EnableIRQ(USART2_IRQn);
 
@@ -78,13 +78,17 @@ void telem_UART_Init(void)
 
 void send_telem_DMA()
 { // set data length and enable channel to start transfer
+    LL_USART_ClearFlag_TC(USART2);
     LL_USART_SetTransferDirection(USART2, LL_USART_DIRECTION_TX);
     //  GPIOB->OTYPER &= 0 << 6;
     LL_DMA_SetDataLength(DMA1, LL_DMA_CHANNEL_4, nbDataToTransmit);
+
+    // enable interrupt - USART Tx transfer complete
+    LL_USART_EnableIT_TC(USART2);
+
     LL_USART_EnableDMAReq_TX(USART2);
 
     LL_DMA_EnableChannel(DMA1, LL_DMA_CHANNEL_4);
-    LL_USART_SetTransferDirection(USART2, LL_USART_DIRECTION_RX);
 }
 
 #else
@@ -153,13 +157,17 @@ void telem_UART_Init(void)
 
 void send_telem_DMA()
 { // set data length and enable channel to start transfer
+    LL_USART_ClearFlag_TC(USART1);
     LL_USART_SetTransferDirection(USART1, LL_USART_DIRECTION_TX);
     //  GPIOB->OTYPER &= 0 << 6;
+
+    // enable interrupt - USART Tx transfer complete
+    LL_USART_EnableIT_TC(USART1);
+
     LL_DMA_SetDataLength(DMA1, LL_DMA_CHANNEL_2, nbDataToTransmit);
     LL_USART_EnableDMAReq_TX(USART1);
 
     LL_DMA_EnableChannel(DMA1, LL_DMA_CHANNEL_2);
-    LL_USART_SetTransferDirection(USART1, LL_USART_DIRECTION_RX);
 }
 
 #endif

--- a/Mcu/f051/Src/stm32f0xx_it.c
+++ b/Mcu/f051/Src/stm32f0xx_it.c
@@ -242,6 +242,31 @@ void USART1_IRQHandler(void)
     /* USER CODE BEGIN USART1_IRQn 0 */
 
     /* USER CODE END USART1_IRQn 0 */
+    if (LL_USART_IsActiveFlag_TC(USART1)) {
+        // Disable TX
+        LL_USART_SetTransferDirection(USART1, LL_USART_DIRECTION_RX);
+        LL_USART_DisableIT_TC(USART1);
+        LL_USART_ClearFlag_TC(USART1);
+    }
+    /* USER CODE BEGIN USART1_IRQn 1 */
+
+    /* USER CODE END USART1_IRQn 1 */
+}
+
+/**
+ * @brief This function handles USART2 global interrupt
+ */
+void USART2_IRQHandler(void)
+{
+    /* USER CODE BEGIN USART1_IRQn 0 */
+
+    /* USER CODE END USART1_IRQn 0 */
+    if (LL_USART_IsActiveFlag_TC(USART2)) {
+        // Disable TX
+        LL_USART_SetTransferDirection(USART2, LL_USART_DIRECTION_RX);
+        LL_USART_DisableIT_TC(USART2);
+        LL_USART_ClearFlag_TC(USART2);
+    }
     /* USER CODE BEGIN USART1_IRQn 1 */
 
     /* USER CODE END USART1_IRQn 1 */


### PR DESCRIPTION
USART Tx channel disabled on TC interrupt once all bytes are transferred.

Inspired by reference manual note on how to use DMA and UART for TX transfers.

https://www.st.com/resource/en/reference_manual/rm0091-stm32f0x1stm32f0x2stm32f0x8-advanced-armbased-32bit-mcus-stmicroelectronics.pdf

Section 27.5.15: USART continuous communication in DMA mode

> In transmission mode, once the DMA has written all the data to be transmitted (the TCIF flag
is set in the DMA_ISR register), the TC flag can be monitored to make sure that the USART
communication is complete. This is required to avoid corrupting the last transmission before
disabling the USART or entering Stop mode. Software must wait until TC=1. The TC flag
remains cleared during all data transfers and it is set by hardware at the end of transmission
of the last frame.

![USART transmission using DMA](https://github.com/user-attachments/assets/38d1c9f5-16ad-48e2-bd7d-8331a8c6c0cf)

