### PR TITLE
make build compatible with gcc 14.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ CFLAGS_BASE += -Wall -Wundef -Wextra -Werror -Wno-unused-parameter -Wno-stringop
 CFLAGS_COMMON := $(CFLAGS_BASE)
 
 # Linker options
-LDFLAGS_COMMON := -specs=nano.specs $(LIBS) -Wl,--gc-sections -Wl,--print-memory-usage
+LDFLAGS_COMMON := -specs=nano.specs $(LIBS) -Wl,--gc-sections -Wl,--print-memory-usage -Wl,--no-warn-rwx-segments
 
 # Search source files
 SRC_COMMON := $(foreach dir,$(SRC_DIRS_COMMON),$(wildcard $(dir)/*.[cs]))

--- a/Src/dummy_syscalls.c
+++ b/Src/dummy_syscalls.c
@@ -1,0 +1,8 @@
+/*
+  dummy system calls to avoid linker errors with gcc 14.x
+ */
+
+int _close_r(void) { return -1; }
+int _lseek_r(void) { return -1; }
+int _read_r(void) { return -1; }
+int _write_r(void) { return -1; }

--- a/Src/main.c
+++ b/Src/main.c
@@ -1591,6 +1591,9 @@ static void checkDeviceInfo(void)
 #define DEVINFO_MAGIC1 0x5925e3da
 #define DEVINFO_MAGIC2 0x4eb863d9
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+
     const struct devinfo {
         uint32_t magic1;
         uint32_t magic2;
@@ -1614,6 +1617,7 @@ static void checkDeviceInfo(void)
             break;
     }
 
+#pragma GCC diagnostic pop
     // TODO: check pin code and reboot to bootloader if incorrect
 
 }

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -4,9 +4,10 @@
 #
 ###############################################################
 
+GCC_VERSION:=14.2.1-1.1
 
 ifeq ($(OS),Windows_NT)
-ARM_SDK_PREFIX:=tools/windows/xpack-arm-none-eabi-gcc-10.3.1-2.3/bin/arm-none-eabi-
+ARM_SDK_PREFIX:=tools/windows/xpack-arm-none-eabi-gcc-$(GCC_VERSION)/bin/arm-none-eabi-
 SHELL:=cmd.exe
 CP:=tools\\windows\\make\\bin\\cp
 DSEP:=\\
@@ -20,7 +21,7 @@ else
 # MacOS and Linux
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-ARM_SDK_PREFIX:=tools/macos/xpack-arm-none-eabi-gcc-10.3.1-2.3/bin/arm-none-eabi-
+ARM_SDK_PREFIX:=tools/macos/xpack-arm-none-eabi-gcc-$(GCC_VERSION)/bin/arm-none-eabi-
 CP:=cp
 DSEP:=/
 NUL:=/dev/null
@@ -30,7 +31,7 @@ CUT:=cut
 FGREP:=fgrep
 else
 # assume Linux
-ARM_SDK_PREFIX:=tools/linux/xpack-arm-none-eabi-gcc-10.3.1-2.3/bin/arm-none-eabi-
+ARM_SDK_PREFIX:=tools/linux/xpack-arm-none-eabi-gcc-$(GCC_VERSION)/bin/arm-none-eabi-
 CP:=cp
 DSEP:=/
 NUL:=/dev/null


### PR DESCRIPTION
note that this will not pass CI at the moment as the tools download doesn't have the gcc 14 compiler

you can download gcc 14.2.1 here:
https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/tag/v14.2.1-1.1
