### PR TITLE
fixed commented targets warning

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -46,5 +46,5 @@ endif
 lc = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,f,$(subst G,g,$(subst H,h,$(subst I,i,$(subst J,j,$(subst K,k,$(subst L,l,$(subst M,m,$(subst N,n,$(subst O,o,$(subst P,p,$(subst Q,q,$(subst R,r,$(subst S,s,$(subst T,t,$(subst U,u,$(subst V,v,$(subst W,w,$(subst X,x,$(subst Y,y,$(subst Z,z,$1))))))))))))))))))))))))))
 
 define get_targets
-$(shell $(FGREP) "define FILE_NAME" Inc/targets.h | $(FGREP) -v DISABLE_BUILD | $(FGREP) _$(1) | $(CUT) -d\" -f2)
+$(shell $(FGREP) "define FILE_NAME" Inc/targets.h | $(FGREP) -v DISABLE_BUILD | $(FGREP) -v "//#" | $(FGREP) _$(1) | $(CUT) -d\" -f2)
 endef


### PR DESCRIPTION
fixes "duplicate" target error

```
Makefile:119: warning: overriding recipe for target 'obj/AM32_SEQURE_TEST_F421_2.17.bin'
Makefile:119: warning: ignoring old recipe for target 'obj/AM32_SEQURE_TEST_F421_2.17.bin'
Makefile:119: warning: overriding recipe for target 'obj/AM32_SEQURE_TEST_F421_2.17.elf'
Makefile:119: warning: ignoring old recipe for target 'obj/AM32_SEQURE_TEST_F421_2.17.elf'
```

the error is caused by the commented out SEQURE_TEST target
