### PR TITLE
L431 DShot Timing fix

### DIFF
--- a/Mcu/l431/Src/IO.c
+++ b/Mcu/l431/Src/IO.c
@@ -68,7 +68,7 @@ void sendDshotDma()
     IC_TIMER_REGISTER->CCMR1 = 0x60;
     IC_TIMER_REGISTER->CCER = 0x3;
     IC_TIMER_REGISTER->PSC = output_timer_prescaler;
-    IC_TIMER_REGISTER->ARR = 115;
+    IC_TIMER_REGISTER->ARR = 110;
 
     IC_TIMER_REGISTER->EGR |= TIM_EGR_UG;
 #ifdef USE_TIMER_3_CHANNEL_1


### PR DESCRIPTION
Since switching to the HSI has been done, the only thing left from https://github.com/am32-firmware/AM32/pull/149 is to fix the DShot timings.
So this is a rebase of the previous PR.

The bit rate for DShot 300 is 5/4 of 300 -->  375kBit/s --> 2.75us/bit
Timer running 40MHz --> 2.75e-6s*40MHz = 110

Using 115 sometimes causes issues leaving the bootloader and sometimes CRC errors. With 110 these issues mostly disappear.