### PR TITLE
Nyxtronics add new ESC targets

### DIFF
--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -1901,6 +1901,33 @@
 #define USE_CUSTOM_LED
 #endif
 
+#ifdef NYXTRONICS_50A_F051
+#define FILE_NAME "NYXTRONICS_50A_F051"
+#define FIRMWARE_NAME "NYXT 50A    "
+#define DEAD_TIME 20
+#define HARDWARE_GROUP_F0_A
+#define TARGET_VOLTAGE_DIVIDER 110
+#define USE_SERIAL_TELEMETRY
+#endif
+
+#ifdef NYXTRONICS_DOUBLE_75A_F051
+#define FILE_NAME "NYXTRONICS_DOUBLE_75A_F051"
+#define FIRMWARE_NAME "NYXT 75A    "
+#define DEAD_TIME 20
+#define HARDWARE_GROUP_F0_A
+#define TARGET_VOLTAGE_DIVIDER 110
+#define USE_SERIAL_TELEMETRY
+#endif
+
+#ifdef NYXTRONICS_DOUBLE_80A_F051
+#define FILE_NAME "NYXTRONICS_DOUBLE_80A_F051"
+#define FIRMWARE_NAME "NYXT 80A    "
+#define DEAD_TIME 40
+#define HARDWARE_GROUP_F0_A
+#define TARGET_VOLTAGE_DIVIDER 110
+#define USE_SERIAL_TELEMETRY
+#endif
+
 /*******************************   G071 Targets
  * *********************************/
 


### PR DESCRIPTION
Hello, let us introduce 3 new targets:
Nyxtronics 4-in-1 6S 50A
Nyxtronics 4-in-1 6S 75A (double MOSFET configuration)
Nyxtronics 4-in-1 8S 80A (double MOSFET configuration,  same hardware as 75A just better MOSFETs)

All of them use the STM32F051+ FD6288 configuration.

Dead times were measured using multiple devices and are approximately:
Nyxtronics 50A ~ 450ns
Nyxtronics 75A ~ 650ns
Nyxtronics 80A ~ 950ns 

Photo of the devices (from left to right: 50A, 50A+, 75A ESCs ):
![IMG_5195(1)](https://github.com/user-attachments/assets/2de09453-9376-4b4b-ba69-cfc1121a0a83)
