### PR TITLE
serial telem: initialize as RX

### DIFF
--- a/Mcu/f051/Src/serial_telemetry.c
+++ b/Mcu/f051/Src/serial_telemetry.c
@@ -140,6 +140,8 @@ void telem_UART_Init(void)
         LL_DMA_GetDataTransferDirection(DMA1, LL_DMA_CHANNEL_2));
     LL_DMA_SetDataLength(DMA1, LL_DMA_CHANNEL_2, sizeof(aTxBuffer));
     LL_USART_EnableDMAReq_TX(USART1);
+
+    LL_USART_SetTransferDirection(USART1, LL_USART_DIRECTION_RX);
 }
 
 void send_telem_DMA(uint8_t bytes)


### PR DESCRIPTION
By default the serial line is configured in TX mode as push-pull. This prevents sharing the serial line with other ESCs if the ESC has not received a telemetry request before. This fixes the issue by ensuring the serial line is initialized as RX.

This should be added to all of the targets. Opening now as a draft to get review, and then I can add to all of the targets if we agree this is the right solution.