### PR TITLE
Change the temperature derating curve to be a continuous function.

### DIFF
--- a/Src/main.c
+++ b/Src/main.c
@@ -2100,9 +2100,10 @@ if(zero_crosses < 5){
 							duty_cycle_maximum = 2000;
 						}
 
-            if (degrees_celsius > eepromBuffer.limits.temperature) {
+            // Temperature derating needs to be a continuous function for UAV control to remain possible.
+            if (degrees_celsius > eepromBuffer.limits.temperature - 10) {
               duty_cycle_maximum = map(degrees_celsius, eepromBuffer.limits.temperature - 10, eepromBuffer.limits.temperature + 10,
-                throttle_max_at_high_rpm / 2, 1);
+                throttle_max_at_high_rpm, 1);
             }
             if (zero_crosses < 100 && commutation_interval > 500) {
               filter_level = 12;


### PR DESCRIPTION
**This is required for UAVs (particularly quads) to remain controllable when operating in the derated regime.**

The derating curve resulting from the existing implementation suffers from a jump discontinuity at the threshold temperature:
<img width="800" height="500" alt="temperature_derating" src="https://github.com/user-attachments/assets/f9dad852-be31-42f9-bc22-ee744828cd42" />

**This causes three issues:**
1. When the temperature rises to the threshold, the ADC noise of the temperature sensor will cause the temperature reading to jump above and below the threshold value rapidly, causing "motor twitching".
2. UAVs, particularly quad copters and similar configurations that use the motor power level for attitude control, require a continuous derating curve for their control to remain stable.
3. UAVs that use the motor for lift would always prefer to slowly lose power so that they can either perform an emergency landing or ideally remain airborne with reduced performance while operating in the derated regime.

**To solve this, I propose a coninuous derating curve:**

<img width="800" height="500" alt="improved_derating" src="https://github.com/user-attachments/assets/d7dcbb39-7921-4f2c-8a83-e5157228b80b" />

Due to thermal inertia, this will still cause slow power-level oscillations when the temperature leaves the linear segment, but the behavior should be much better than the existing one. Arguably, the thermal derating could start even sooner and roll slower, to avoid these slower power oscillations, but this depends on how much thermal mass the ESC hardware has, so I won't change it for now.
