### PR TITLE
dshot: fix beacon count

### DIFF
--- a/Src/dshot.c
+++ b/Src/dshot.c
@@ -138,7 +138,7 @@ void computeDshotDMA()
                     last_command = dshotcommand;
                     command_count = 0;
                 }
-                if (dshotcommand < 5) { // beacons
+                if (dshotcommand <= 5) { // beacons
                     command_count = 6; // go on right away
                 }
                 command_count++;


### PR DESCRIPTION
dshot commands 1-5 trigger beacons, but the conditional to allow instant beacon triggers doesn't include command 5.

This PR fixes the conditional to include command 5