### PR TITLE
dshot: improve EDT emission

### DIFF
--- a/Inc/common.h
+++ b/Inc/common.h
@@ -46,7 +46,6 @@ extern uint32_t current_GPIO_PORT;
 #endif
 extern uint32_t current_EXTI_LINE;
 extern int e_com_time;
-extern char dshot_extended_telemetry;
 extern char EDT_ARM_ENABLE;
 extern char EDT_ARMED;
 extern uint16_t send_extended_dshot;

--- a/Src/main.c
+++ b/Src/main.c
@@ -1916,21 +1916,6 @@ if(zero_crosses < 5){
 
         if (tenkhzcounter > LOOP_FREQUENCY_HZ) { // 1s sample interval 10000
             consumed_current += (actual_current << 16) / 360;
-            switch (dshot_extended_telemetry) {
-
-            case 1:
-                send_extended_dshot = 0b0010 << 8 | degrees_celsius;
-                dshot_extended_telemetry = 2;
-                break;
-            case 2:
-                send_extended_dshot = 0b0110 << 8 | (uint8_t)actual_current / 50;
-                dshot_extended_telemetry = 3;
-                break;
-            case 3:
-                send_extended_dshot = 0b0100 << 8 | (uint8_t)(battery_voltage / 25);
-                dshot_extended_telemetry = 1;
-                break;
-            }
             tenkhzcounter = 0;
         }
 


### PR DESCRIPTION
**Problem**
Extended DShot Telemetry (EDT) is currently emitted at 1Hz and rotates between Temp/Volt/Curr, resulting in a 3s update interval for each value. On systems that round-robin the bdshot frames (ArduPilot and PX4), this becomes a random but roughly 12s interval.

**Solution**
Replaces fixed 1Hz EDT emission with counter-based ratio scheduling and guaranteed eRPM interleaving.

- moved logic from main.c to dshot.c
- counter based scheduling rather than time based
- always emit an eRPM frame after an EDT frame
- chose divisors for higher rate EDT emission (**discussion point**)

**Testing**
Tested with PX4 which is sending DShot at 800Hz and processing bdshot frames in a round-robin fashion (sampling every 4th measurement):
```
INFO  [arch_dshot] Ch0:  eRPM: 196.7Hz  Temp: 0.9Hz  Volt: 0.9Hz  Curr: 5.7Hz
INFO  [arch_dshot] Ch1:  eRPM: 201.6Hz  Temp: 0.9Hz  Volt: 0.9Hz  Curr: 6.1Hz
INFO  [arch_dshot] Ch2:  eRPM: 201.6Hz  Temp: 0.9Hz  Volt: 0.9Hz  Curr: 6.5Hz
INFO  [arch_dshot] Ch3:  eRPM: 199.8Hz  Temp: 0.9Hz  Volt: 0.9Hz  Curr: 6.1Hz
```

Fixes https://github.com/am32-firmware/AM32/issues/241