### PR TITLE
add DRONECAN_NODE_NAME in pogo target

### DIFF
--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -281,6 +281,7 @@
 #endif
 
 #ifdef POGO_L431_CAN
+#define DRONECAN_NODE_NAME "pogo.canesc"
 #define FIRMWARE_NAME "pogo.canesc"
 #define FILE_NAME "POGO_L431_CAN"
 #define DRONECAN_SUPPORT 1


### PR DESCRIPTION
@AlkaMotors Hi, Alka
Add the DRONECAN_NODE_NAME definition to the pogo target to adapt to the DroneCAN node name display logic added by huibean, e.g., pogo.canesc#M1.