### PR TITLE
feat(eeprom): add version-aware eeprom.json schema synced with eeprom.h

### DIFF
--- a/.github/workflows/eeprom-publish.yml
+++ b/.github/workflows/eeprom-publish.yml
@@ -1,0 +1,45 @@
+name: Publish EEPROM Schema
+
+# On a release tag, publish Inc/eeprom.json to am32.ca so configurators (the
+# AM32 Configurator and QGroundControl) can fetch a version-aware schema.
+#
+# The upload transport is not wired yet (pending the am32.ca deploy mechanism).
+# Until the deploy secret is set the upload step skips with a notice, so this
+# workflow is safe to keep enabled. To finish it, add the deploy secret in the
+# repo settings and replace the TODO in the "Publish to am32.ca" step.
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+'
+  workflow_dispatch:
+
+jobs:
+  publish-schema:
+    name: Publish schema to am32.ca
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      # Gate: never publish a schema that disagrees with the released header.
+      - name: Check eeprom.h and eeprom.json are in sync
+        run: python generate_eeprom.py --check
+
+      - name: Publish to am32.ca
+        env:
+          # TODO(freasy): the secret name/shape depends on the transport
+          # (static-site repo token, object-store creds, API token, or SSH key).
+          DEPLOY_TOKEN: ${{ secrets.AM32CA_DEPLOY_TOKEN }}
+        run: |
+          if [ -z "$DEPLOY_TOKEN" ]; then
+            echo "::notice title=Schema publish not configured::am32.ca deploy mechanism is not wired yet. Inc/eeprom.json for ${GITHUB_REF_NAME} was validated but not uploaded."
+            exit 0
+          fi
+          # TODO(freasy): upload Inc/eeprom.json to the rolling am32.ca/eeprom URL using $DEPLOY_TOKEN.
+          echo "Publishing Inc/eeprom.json to am32.ca/eeprom for ${GITHUB_REF_NAME}..."

--- a/.github/workflows/eeprom-schema.yml
+++ b/.github/workflows/eeprom-schema.yml
@@ -1,0 +1,44 @@
+name: EEPROM Schema Validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Inc/eeprom.json'
+      - 'Inc/eeprom.h'
+      - 'generate_eeprom.py'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Inc/eeprom.json'
+      - 'Inc/eeprom.h'
+      - 'generate_eeprom.py'
+
+jobs:
+  validate:
+    name: Validate Schema
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Validate JSON syntax
+        run: python -c "import json; json.load(open('Inc/eeprom.json'))"
+
+      - name: Check eeprom.h and eeprom.json are in sync
+        run: python generate_eeprom.py --check
+
+  notify-schema-update:
+    name: Schema Update Notice
+    runs-on: ubuntu-latest
+    needs: validate
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - name: Post update reminder
+        run: |
+          echo "::notice title=Schema Updated::Inc/eeprom.json has been merged to main. Remember to update the hosted schema at am32.ca/eeprom"

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Keil_Projects/Listings
 /Debug/
 windows-tools.zip
 .settings/
+__pycache__/

--- a/Inc/eeprom.h
+++ b/Inc/eeprom.h
@@ -7,22 +7,22 @@
 
 typedef union EEprom_u {
     struct {
-        uint8_t reserved_0; //0
-        uint8_t eeprom_version; //1
-        uint8_t reserved_1; //2
-        struct {        
-            uint8_t major; //3
-            uint8_t minor; //4
+        uint8_t reserved_0; // 0
+        uint8_t eeprom_version; // 1
+        uint8_t reserved_1; // 2
+        struct {
+            uint8_t major; // 3
+            uint8_t minor; // 4
         } version;
-        uint8_t max_ramp;    //5 0.1% per ms to 25% per ms 
-        uint8_t minimum_duty_cycle; //6  0.2% to 51 percent
-        uint8_t disable_stick_calibration; //7 
-        uint8_t absolute_voltage_cutoff;  //8  voltage level 1 to 100 in 0.5v increments
-        uint8_t current_P; //9  0-255
-        uint8_t current_I; //10 0-255
-        uint8_t current_D; //11 0-255
-        uint8_t active_brake_power; //12  1-5 percent duty cycle
-        char reserved_eeprom_3[4]; //13-16  
+        uint8_t max_ramp; // 5
+        uint8_t minimum_duty_cycle; // 6
+        uint8_t disable_stick_calibration; // 7
+        uint8_t absolute_voltage_cutoff; // 8
+        uint8_t current_P; // 9
+        uint8_t current_I; // 10
+        uint8_t current_D; // 11
+        uint8_t active_brake_power; // 12
+        char reserved_eeprom_3[4]; // 13
         uint8_t dir_reversed; // 17
         uint8_t bi_direction; // 18
         uint8_t use_sine_start; // 19
@@ -34,7 +34,7 @@ typedef union EEprom_u {
         uint8_t startup_power; // 25
         uint8_t motor_kv; // 26
         uint8_t motor_poles; // 27
-        uint8_t brake_on_stop; // 28 
+        uint8_t brake_on_stop; // 28
         uint8_t stall_protection; // 29
         uint8_t beep_volume; // 30
         uint8_t telemetry_on_interval; // 31
@@ -58,7 +58,7 @@ typedef union EEprom_u {
         uint8_t sine_mode_power; // 45
         uint8_t input_type; // 46
         uint8_t auto_advance; // 47
-        uint8_t tune[128]; // 48-175
+        uint8_t tune[128]; // 48
         struct {
             uint8_t can_node; // 176
             uint8_t esc_index; // 177
@@ -68,7 +68,7 @@ typedef union EEprom_u {
             uint8_t filter_hz; // 181
             uint8_t debug_rate; // 182
             uint8_t term_enable; // 183
-            uint8_t reserved[8]; // 184-191
+            uint8_t reserved[8]; // 184
         } can;
     };
     uint8_t buffer[192];
@@ -76,9 +76,6 @@ typedef union EEprom_u {
 
 extern EEprom_t eepromBuffer;
 
-// void save_to_flash(uint8_t *data);
-// void read_flash(uint8_t* data, uint32_t address);
-// void save_to_flash_bin(uint8_t *data, int length, uint32_t add);
 void read_flash_bin(uint8_t* data, uint32_t add, int out_buff_len);
 void save_flash_nolib(uint8_t* data, int length, uint32_t add);
 

--- a/Inc/eeprom.json
+++ b/Inc/eeprom.json
@@ -217,7 +217,7 @@
       "cName": "active_brake_power",
       "raw": {
         "min": 0,
-        "max": 10
+        "max": 5
       }
     },
 

--- a/Inc/eeprom.json
+++ b/Inc/eeprom.json
@@ -1,0 +1,924 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/am32-firmware/AM32/am32-eeprom-schema.json",
+  "title": "AM32 EEPROM Settings Schema",
+  "description": "Unified schema for AM32 ESC EEPROM layout, settings metadata, and version-specific behavior",
+  "version": "1.0.2",
+
+  "eepromVersions": {
+    "2": {
+      "description": "Legacy EEPROM format (pre-extended settings)",
+      "minSize": 48,
+      "bufferSize": 192,
+      "notes": "Original format without extended settings like current PID. Offsets 5-16 contained ESC name string."
+    },
+    "3": {
+      "description": "Extended settings format",
+      "minSize": 48,
+      "bufferSize": 192,
+      "notes": "Added current PID, ramp rate, min duty cycle, absolute voltage cutoff at offsets 5-12"
+    },
+    "4": {
+      "description": "CAN settings format",
+      "minSize": 184,
+      "bufferSize": 192,
+      "notes": "Added CAN bus configuration at offset 176-191"
+    }
+  },
+
+  "fields": {
+    "bootByte": {
+      "offset": 0,
+      "size": 1,
+      "type": "uint8",
+      "name": "Boot Byte",
+      "description": "Boot indicator byte (0x01 = valid)",
+      "readOnly": true,
+      "cName": "reserved_0"
+    },
+
+    "eepromVersion": {
+      "offset": 1,
+      "size": 1,
+      "type": "uint8",
+      "name": "EEPROM Version",
+      "description": "Layout revision number",
+      "readOnly": true,
+      "cName": "eeprom_version"
+    },
+
+    "bootloaderVersion": {
+      "offset": 2,
+      "size": 1,
+      "type": "uint8",
+      "name": "Bootloader Version",
+      "readOnly": true,
+      "cName": "reserved_1"
+    },
+
+    "firmwareMajor": {
+      "offset": 3,
+      "size": 1,
+      "type": "uint8",
+      "name": "Firmware Major Version",
+      "readOnly": true,
+      "cName": "version.major"
+    },
+
+    "firmwareMinor": {
+      "offset": 4,
+      "size": 1,
+      "type": "uint8",
+      "name": "Firmware Minor Version",
+      "readOnly": true,
+      "cName": "version.minor"
+    },
+
+    "maxRampSpeed": {
+      "offset": 5,
+      "size": 1,
+      "type": "number",
+      "name": "Max Ramp Speed",
+      "description": "Maximum throttle ramp rate",
+      "unit": "% per ms",
+      "minEepromVersion": 3,
+      "cName": "max_ramp",
+      "raw": {
+        "min": 1,
+        "max": 200
+      },
+      "display": {
+        "min": 0.1,
+        "max": 20.0,
+        "factor": 0.1,
+        "offset": 0,
+        "decimals": 1
+      }
+    },
+
+    "minDutyCycle": {
+      "offset": 6,
+      "size": 1,
+      "type": "number",
+      "name": "Minimum Duty Cycle",
+      "description": "Minimum motor duty cycle",
+      "unit": "%",
+      "minEepromVersion": 3,
+      "cName": "minimum_duty_cycle",
+      "raw": {
+        "min": 0,
+        "max": 50
+      },
+      "display": {
+        "min": 0.0,
+        "max": 25.0,
+        "factor": 0.5,
+        "offset": 0,
+        "decimals": 1
+      }
+    },
+
+    "disableStickCalibration": {
+      "offset": 7,
+      "size": 1,
+      "type": "bool",
+      "name": "Disable Stick Calibration",
+      "description": "Disable automatic throttle range calibration",
+      "minEepromVersion": 3,
+      "cName": "disable_stick_calibration"
+    },
+
+    "absoluteVoltageCutoff": {
+      "offset": 8,
+      "size": 1,
+      "type": "number",
+      "name": "Absolute Voltage Cutoff",
+      "description": "Fixed voltage cutoff threshold (when low voltage mode = Absolute)",
+      "unit": "V",
+      "minEepromVersion": 3,
+      "cName": "absolute_voltage_cutoff",
+      "raw": {
+        "min": 1,
+        "max": 100
+      },
+      "display": {
+        "min": 0.5,
+        "max": 50.0,
+        "factor": 0.5,
+        "offset": 0,
+        "decimals": 1
+      }
+    },
+
+    "currentPidP": {
+      "offset": 9,
+      "size": 1,
+      "type": "number",
+      "name": "Current PID P",
+      "description": "Proportional gain for current control loop",
+      "minEepromVersion": 3,
+      "cName": "current_P",
+      "raw": {
+        "min": 0,
+        "max": 255
+      },
+      "display": {
+        "min": 0,
+        "max": 510,
+        "factor": 2,
+        "offset": 0,
+        "decimals": 0
+      }
+    },
+
+    "currentPidI": {
+      "offset": 10,
+      "size": 1,
+      "type": "uint8",
+      "name": "Current PID I",
+      "description": "Integral gain for current control loop",
+      "minEepromVersion": 3,
+      "cName": "current_I",
+      "raw": {
+        "min": 0,
+        "max": 255
+      }
+    },
+
+    "currentPidD": {
+      "offset": 11,
+      "size": 1,
+      "type": "number",
+      "name": "Current PID D",
+      "description": "Derivative gain for current control loop",
+      "minEepromVersion": 3,
+      "cName": "current_D",
+      "raw": {
+        "min": 0,
+        "max": 255
+      },
+      "display": {
+        "min": 0,
+        "max": 510,
+        "factor": 2,
+        "offset": 0,
+        "decimals": 0
+      }
+    },
+
+    "activeBrakePower": {
+      "offset": 12,
+      "size": 1,
+      "type": "uint8",
+      "name": "Active Brake Power",
+      "description": "Active braking duty cycle",
+      "unit": "%",
+      "minEepromVersion": 3,
+      "cName": "active_brake_power",
+      "raw": {
+        "min": 0,
+        "max": 10
+      }
+    },
+
+    "reserved0": {
+      "offset": 13,
+      "size": 4,
+      "type": "reserved",
+      "name": "Reserved",
+      "description": "Reserved bytes for future use",
+      "cName": "reserved_eeprom_3",
+      "hidden": true
+    },
+
+    "directionReversed": {
+      "offset": 17,
+      "size": 1,
+      "type": "bool",
+      "name": "Direction Reversed",
+      "description": "Reverse motor rotation direction",
+      "cName": "dir_reversed"
+    },
+
+    "bidirectionalMode": {
+      "offset": 18,
+      "size": 1,
+      "type": "bool",
+      "name": "Bidirectional Mode",
+      "description": "Enable 3D mode (forward and reverse)",
+      "cName": "bi_direction"
+    },
+
+    "sineStartup": {
+      "offset": 19,
+      "size": 1,
+      "type": "bool",
+      "name": "Sinusoidal Startup",
+      "description": "Use sinusoidal commutation during startup",
+      "cName": "use_sine_start"
+    },
+
+    "complementaryPwm": {
+      "offset": 20,
+      "size": 1,
+      "type": "bool",
+      "name": "Complementary PWM",
+      "description": "Enable complementary PWM mode",
+      "cName": "comp_pwm"
+    },
+
+    "variablePwmFreq": {
+      "offset": 21,
+      "size": 1,
+      "type": "enum",
+      "name": "Variable PWM Frequency",
+      "description": "PWM frequency mode",
+      "cName": "variable_pwm",
+      "versions": {
+        "default": {
+          "values": [
+            { "raw": 0, "name": "Off", "description": "Fixed PWM frequency" },
+            { "raw": 1, "name": "On", "description": "Variable PWM frequency" }
+          ]
+        },
+        "firmware:2.18+": {
+          "values": [
+            { "raw": 0, "name": "Fixed", "description": "Fixed PWM frequency" },
+            { "raw": 1, "name": "Variable", "description": "Variable PWM frequency" },
+            { "raw": 2, "name": "By RPM", "description": "PWM frequency varies with RPM" }
+          ]
+        }
+      }
+    },
+
+    "stuckRotorProtection": {
+      "offset": 22,
+      "size": 1,
+      "type": "bool",
+      "name": "Stuck Rotor Protection",
+      "description": "Stop motor if rotor is stuck",
+      "cName": "stuck_rotor_protection"
+    },
+
+    "timingAdvance": {
+      "offset": 23,
+      "size": 1,
+      "type": "number",
+      "name": "Timing Advance",
+      "description": "Motor commutation timing advance angle (0.9375° per internal unit)",
+      "unit": "°",
+      "cName": "advance_level",
+      "versions": {
+        "default": {
+          "raw": {
+            "min": 0,
+            "max": 3
+          },
+          "display": {
+            "min": 0,
+            "max": 22.5,
+            "factor": 7.5,
+            "offset": 0,
+            "decimals": 1
+          },
+          "notes": "Old format: raw 0-3 maps to 0°, 7.5°, 15°, 22.5°"
+        },
+        "eeprom:3+": {
+          "raw": {
+            "min": 10,
+            "max": 42
+          },
+          "display": {
+            "min": 0,
+            "max": 30,
+            "factor": 0.9375,
+            "offset": -9.375,
+            "decimals": 1
+          },
+          "notes": "New format: raw 10-42 stored in EEPROM, internally converted to 0-32, then multiplied by 0.9375 for degrees"
+        }
+      }
+    },
+
+    "pwmFrequency": {
+      "offset": 24,
+      "size": 1,
+      "type": "uint8",
+      "name": "PWM Frequency",
+      "description": "Base PWM switching frequency",
+      "unit": "kHz",
+      "cName": "pwm_frequency",
+      "versions": {
+        "default": {
+          "raw": {
+            "min": 8,
+            "max": 48
+          }
+        },
+        "eeprom:3+": {
+          "raw": {
+            "min": 8,
+            "max": 144
+          }
+        }
+      }
+    },
+
+    "startupPower": {
+      "offset": 25,
+      "size": 1,
+      "type": "uint8",
+      "name": "Startup Power",
+      "description": "Power level during motor startup",
+      "unit": "%",
+      "cName": "startup_power",
+      "raw": {
+        "min": 50,
+        "max": 150
+      }
+    },
+
+    "motorKv": {
+      "offset": 26,
+      "size": 1,
+      "type": "number",
+      "name": "Motor KV",
+      "description": "Motor KV rating (RPM per volt)",
+      "unit": "RPM/V",
+      "cName": "motor_kv",
+      "raw": {
+        "min": 0,
+        "max": 255
+      },
+      "display": {
+        "min": 20,
+        "max": 10220,
+        "factor": 40,
+        "offset": 20,
+        "decimals": 0
+      }
+    },
+
+    "motorPoles": {
+      "offset": 27,
+      "size": 1,
+      "type": "uint8",
+      "name": "Motor Poles",
+      "description": "Number of motor magnetic poles",
+      "cName": "motor_poles",
+      "raw": {
+        "min": 2,
+        "max": 64
+      }
+    },
+
+    "brakeOnStop": {
+      "offset": 28,
+      "size": 1,
+      "type": "enum",
+      "name": "Brake on Stop",
+      "description": "Braking behavior when throttle is at minimum",
+      "cName": "brake_on_stop",
+      "values": [
+        { "raw": 0, "name": "Off", "description": "No braking when stopped" },
+        { "raw": 1, "name": "Brake", "description": "Apply brake when throttle is at minimum" },
+        { "raw": 2, "name": "Active Brake", "description": "Active braking mode (requires arming)" }
+      ]
+    },
+
+    "stallProtection": {
+      "offset": 29,
+      "size": 1,
+      "type": "uint8",
+      "name": "Stall Protection",
+      "description": "Low-RPM anti-stall for crawlers/RC cars. 0 disables; any non-zero value enables a low-RPM throttle boost, and the magnitude also sets the startup commutation window that enforces the minimum duty floor (larger values shorten it).",
+      "cName": "stall_protection"
+    },
+
+    "beepVolume": {
+      "offset": 30,
+      "size": 1,
+      "type": "uint8",
+      "name": "Beep Volume",
+      "description": "Startup beep volume level",
+      "cName": "beep_volume",
+      "raw": {
+        "min": 0,
+        "max": 11
+      }
+    },
+
+    "telemetry30ms": {
+      "offset": 31,
+      "size": 1,
+      "type": "uint8",
+      "name": "30ms Interval Telemetry",
+      "description": "Telemetry timing. 0 uses the default; 1 enables the ~30 ms interval; values 2 or more add to the interval to stagger telemetry between ESCs on a shared bus.",
+      "cName": "telemetry_on_interval"
+    },
+
+    "servoLowThreshold": {
+      "offset": 32,
+      "size": 1,
+      "type": "number",
+      "name": "Servo Low Threshold",
+      "description": "Minimum servo pulse width for zero throttle",
+      "unit": "us",
+      "cName": "servo.low_threshold",
+      "raw": {
+        "min": 0,
+        "max": 250
+      },
+      "display": {
+        "min": 750,
+        "max": 1250,
+        "factor": 2,
+        "offset": 750,
+        "decimals": 0
+      }
+    },
+
+    "servoHighThreshold": {
+      "offset": 33,
+      "size": 1,
+      "type": "number",
+      "name": "Servo High Threshold",
+      "description": "Maximum servo pulse width for full throttle",
+      "unit": "us",
+      "cName": "servo.high_threshold",
+      "raw": {
+        "min": 0,
+        "max": 250
+      },
+      "display": {
+        "min": 1750,
+        "max": 2250,
+        "factor": 2,
+        "offset": 1750,
+        "decimals": 0
+      }
+    },
+
+    "servoNeutral": {
+      "offset": 34,
+      "size": 1,
+      "type": "number",
+      "name": "Servo Neutral",
+      "description": "Servo pulse width for neutral position (3D mode)",
+      "unit": "us",
+      "cName": "servo.neutral",
+      "raw": {
+        "min": 0,
+        "max": 255
+      },
+      "display": {
+        "min": 1374,
+        "max": 1629,
+        "factor": 1,
+        "offset": 1374,
+        "decimals": 0
+      }
+    },
+
+    "servoDeadband": {
+      "offset": 35,
+      "size": 1,
+      "type": "uint8",
+      "name": "Servo Deadband",
+      "description": "Deadband around neutral position",
+      "cName": "servo.dead_band",
+      "raw": {
+        "min": 0,
+        "max": 100
+      }
+    },
+
+    "lowVoltageCutoff": {
+      "offset": 36,
+      "size": 1,
+      "type": "enum",
+      "name": "Low Voltage Cutoff",
+      "description": "Low voltage protection mode",
+      "cName": "low_voltage_cut_off",
+      "versions": {
+        "default": {
+          "values": [
+            { "raw": 0, "name": "Off", "description": "No low voltage protection" },
+            { "raw": 1, "name": "On", "description": "Cell-based voltage cutoff" }
+          ]
+        },
+        "firmware:2.19+": {
+          "values": [
+            { "raw": 0, "name": "Off", "description": "No low voltage protection" },
+            { "raw": 1, "name": "Cell Based", "description": "Per-cell voltage threshold" },
+            { "raw": 2, "name": "Absolute", "description": "Fixed voltage threshold" }
+          ]
+        }
+      }
+    },
+
+    "lowVoltageThreshold": {
+      "offset": 37,
+      "size": 1,
+      "type": "number",
+      "name": "Low Voltage Threshold",
+      "description": "Per-cell voltage cutoff threshold",
+      "unit": "V",
+      "cName": "low_cell_volt_cutoff",
+      "raw": {
+        "min": 0,
+        "max": 100
+      },
+      "display": {
+        "min": 2.50,
+        "max": 3.50,
+        "factor": 0.01,
+        "offset": 2.50,
+        "decimals": 2
+      }
+    },
+
+    "rcCarReversing": {
+      "offset": 38,
+      "size": 1,
+      "type": "bool",
+      "name": "RC Car Reversing",
+      "description": "Enable RC car style brake-then-reverse behavior",
+      "cName": "rc_car_reverse"
+    },
+
+    "hallSensors": {
+      "offset": 39,
+      "size": 1,
+      "type": "bool",
+      "name": "Hall Sensors",
+      "description": "Use hall sensor feedback for commutation",
+      "cName": "use_hall_sensors"
+    },
+
+    "sineModeRange": {
+      "offset": 40,
+      "size": 1,
+      "type": "uint8",
+      "name": "Sine Mode Range",
+      "description": "Throttle range for sine mode operation",
+      "unit": "%",
+      "cName": "sine_mode_changeover_thottle_level",
+      "raw": {
+        "min": 5,
+        "max": 25
+      }
+    },
+
+    "dragBrakeStrength": {
+      "offset": 41,
+      "size": 1,
+      "type": "uint8",
+      "name": "Drag Brake Strength",
+      "description": "Brake strength when throttle released",
+      "cName": "drag_brake_strength",
+      "raw": {
+        "min": 1,
+        "max": 10
+      }
+    },
+
+    "runningBrakeLevel": {
+      "offset": 42,
+      "size": 1,
+      "type": "uint8",
+      "name": "Running Brake Level",
+      "description": "Brake level during deceleration",
+      "cName": "driving_brake_strength",
+      "raw": {
+        "min": 1,
+        "max": 10
+      }
+    },
+
+    "temperatureLimit": {
+      "offset": 43,
+      "size": 1,
+      "type": "uint8",
+      "name": "Temperature Limit",
+      "description": "Maximum ESC temperature before throttling",
+      "unit": "°C",
+      "cName": "limits.temperature",
+      "raw": {
+        "min": 70,
+        "max": 140
+      },
+      "disabledValue": {
+        "raw": 255,
+        "display": "Disabled"
+      }
+    },
+
+    "currentLimit": {
+      "offset": 44,
+      "size": 1,
+      "type": "number",
+      "name": "Current Limit",
+      "description": "Maximum motor current",
+      "unit": "A",
+      "cName": "limits.current",
+      "raw": {
+        "min": 0,
+        "max": 100
+      },
+      "display": {
+        "min": 0,
+        "max": 200,
+        "factor": 2,
+        "offset": 0,
+        "decimals": 0
+      },
+      "disabledValue": {
+        "raw": 0,
+        "display": "Disabled"
+      }
+    },
+
+    "sineModePower": {
+      "offset": 45,
+      "size": 1,
+      "type": "uint8",
+      "name": "Sine Mode Power",
+      "description": "Power level during sine mode startup",
+      "cName": "sine_mode_power",
+      "raw": {
+        "min": 1,
+        "max": 10
+      }
+    },
+
+    "inputType": {
+      "offset": 46,
+      "size": 1,
+      "type": "enum",
+      "name": "Input Type",
+      "description": "ESC input protocol",
+      "cName": "input_type",
+      "values": [
+        { "raw": 0, "name": "Auto", "description": "Automatically detect input protocol" },
+        { "raw": 1, "name": "DShot", "description": "DShot digital protocol" },
+        { "raw": 2, "name": "Servo", "description": "Standard PWM servo signal" },
+        { "raw": 3, "name": "Serial", "description": "Serial communication" },
+        { "raw": 4, "name": "EDT ARM", "description": "EDT arming protocol" },
+        { "raw": 5, "name": "DroneCAN", "description": "DroneCAN input protocol" }
+      ]
+    },
+
+    "autoTiming": {
+      "offset": 47,
+      "size": 1,
+      "type": "bool",
+      "name": "Auto Timing",
+      "description": "Automatically adjust commutation timing",
+      "minFirmwareVersion": "2.16",
+      "cName": "auto_advance"
+    },
+
+    "startupMelody": {
+      "offset": 48,
+      "size": 128,
+      "type": "bluejay",
+      "name": "Startup Melody",
+      "description": "Startup tune stored as a 128-byte Bluejay binary blob (custom 8-bit frequency/duration encoding, not ASCII RTTTL)",
+      "cName": "tune"
+    },
+
+    "canNode": {
+      "offset": 176,
+      "size": 1,
+      "type": "uint8",
+      "name": "CAN Node ID",
+      "description": "CAN bus node identifier",
+      "minEepromVersion": 4,
+      "cName": "can.can_node",
+      "raw": {
+        "min": 0,
+        "max": 127
+      }
+    },
+
+    "canEscIndex": {
+      "offset": 177,
+      "size": 1,
+      "type": "uint8",
+      "name": "CAN ESC Index",
+      "description": "ESC index for CAN communication",
+      "minEepromVersion": 4,
+      "cName": "can.esc_index",
+      "raw": {
+        "min": 0,
+        "max": 31
+      }
+    },
+
+    "canRequireArming": {
+      "offset": 178,
+      "size": 1,
+      "type": "bool",
+      "name": "CAN Require Arming",
+      "description": "Require arming command before motor start",
+      "minEepromVersion": 4,
+      "cName": "can.require_arming"
+    },
+
+    "canTelemRate": {
+      "offset": 179,
+      "size": 1,
+      "type": "uint8",
+      "name": "CAN Telemetry Rate",
+      "description": "CAN telemetry transmission rate",
+      "unit": "Hz",
+      "minEepromVersion": 4,
+      "cName": "can.telem_rate",
+      "raw": {
+        "min": 0,
+        "max": 200
+      }
+    },
+
+    "canRequireZeroThrottle": {
+      "offset": 180,
+      "size": 1,
+      "type": "bool",
+      "name": "CAN Require Zero Throttle",
+      "description": "Require zero throttle before arming",
+      "minEepromVersion": 4,
+      "cName": "can.require_zero_throttle"
+    },
+
+    "canFilterHz": {
+      "offset": 181,
+      "size": 1,
+      "type": "uint8",
+      "name": "CAN Filter Hz",
+      "description": "CAN input filter frequency",
+      "unit": "Hz",
+      "minEepromVersion": 4,
+      "cName": "can.filter_hz",
+      "raw": {
+        "min": 0,
+        "max": 100
+      }
+    },
+
+    "canDebugRate": {
+      "offset": 182,
+      "size": 1,
+      "type": "uint8",
+      "name": "CAN Debug Rate",
+      "description": "CAN debug message rate",
+      "unit": "Hz",
+      "minEepromVersion": 4,
+      "cName": "can.debug_rate",
+      "raw": {
+        "min": 0,
+        "max": 200
+      }
+    },
+
+    "canTermEnable": {
+      "offset": 183,
+      "size": 1,
+      "type": "bool",
+      "name": "CAN Termination Enable",
+      "description": "Enable CAN bus termination resistor",
+      "minEepromVersion": 4,
+      "cName": "can.term_enable"
+    },
+
+    "canReserved": {
+      "offset": 184,
+      "size": 8,
+      "type": "uint8",
+      "name": "CAN Reserved",
+      "description": "Reserved bytes for future CAN settings",
+      "minEepromVersion": 4,
+      "cName": "can.reserved"
+    }
+  },
+
+  "groups": {
+    "info": {
+      "name": "ESC Information",
+      "fields": ["bootByte", "eepromVersion", "bootloaderVersion", "firmwareMajor", "firmwareMinor"],
+      "description": "Read-only ESC identification and version information"
+    },
+    "motor": {
+      "name": "Motor Settings",
+      "fields": ["directionReversed", "bidirectionalMode", "motorKv", "motorPoles", "timingAdvance", "autoTiming", "startupPower", "pwmFrequency", "variablePwmFreq", "complementaryPwm", "stuckRotorProtection", "stallProtection", "hallSensors"],
+      "description": "Motor configuration and commutation settings"
+    },
+    "extended": {
+      "name": "Extended Settings",
+      "fields": ["maxRampSpeed", "minDutyCycle", "disableStickCalibration"],
+      "description": "Extended motor control settings (EEPROM v3+)",
+      "minEepromVersion": 3
+    },
+    "limits": {
+      "name": "Limits",
+      "fields": ["temperatureLimit", "currentLimit", "lowVoltageCutoff", "lowVoltageThreshold", "absoluteVoltageCutoff"],
+      "description": "Protection limits and cutoffs"
+    },
+    "currentControl": {
+      "name": "Current Control",
+      "fields": ["currentPidP", "currentPidI", "currentPidD"],
+      "description": "Current control PID tuning (EEPROM v3+)",
+      "minEepromVersion": 3
+    },
+    "sineStartup": {
+      "name": "Sinusoidal Startup",
+      "fields": ["sineStartup", "sineModeRange", "sineModePower"],
+      "description": "Sinusoidal startup mode settings"
+    },
+    "brake": {
+      "name": "Brake",
+      "fields": ["brakeOnStop", "rcCarReversing", "dragBrakeStrength", "runningBrakeLevel", "activeBrakePower"],
+      "description": "Braking behavior settings"
+    },
+    "servo": {
+      "name": "Servo Settings",
+      "fields": ["servoLowThreshold", "servoHighThreshold", "servoNeutral", "servoDeadband"],
+      "description": "PWM servo input calibration"
+    },
+    "misc": {
+      "name": "Miscellaneous",
+      "fields": ["beepVolume", "telemetry30ms", "inputType", "startupMelody"],
+      "description": "Other ESC settings"
+    },
+    "can": {
+      "name": "CAN Bus",
+      "fields": ["canNode", "canEscIndex", "canRequireArming", "canTelemRate", "canRequireZeroThrottle", "canFilterHz", "canDebugRate", "canTermEnable"],
+      "description": "CAN bus communication settings (EEPROM v4+)",
+      "minEepromVersion": 4
+    }
+  },
+
+  "meta": {
+    "maintainer": "AM32 Project",
+    "repository": "https://github.com/am32-firmware/AM32",
+    "license": "GPL-3.0",
+    "lastUpdated": "2026-05-30",
+    "consumers": [
+      {
+        "name": "AM32 Firmware",
+        "language": "C",
+        "usage": "Source of truth for EEPROM struct layout"
+      },
+      {
+        "name": "AM32 Configurator",
+        "language": "TypeScript/Vue",
+        "usage": "Web-based ESC configuration tool"
+      },
+      {
+        "name": "QGroundControl",
+        "language": "C++/QML",
+        "usage": "Ground control station ESC settings"
+      }
+    ]
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ QUIET = @
 CC = $(ARM_SDK_PREFIX)gcc
 OBJCOPY = $(ARM_SDK_PREFIX)objcopy
 ECHO = echo
+PYTHON ?= python3
 
 # common variables
 IDENTIFIER := AM32
@@ -80,6 +81,14 @@ $(foreach MCU,$(MCU_TYPES),$(eval $(call CREATE_TARGET,$(MCU))))
 clean :
 	@echo Removing $(OBJ) directory
 	@$(RM) -rf $(OBJ)
+
+# eeprom.h is the hand-edited source of truth for the EEPROM layout; Inc/eeprom.json
+# mirrors it (plus configurator metadata). 'make eeprom-check' (and the eeprom-schema
+# CI job) flag any divergence. The firmware build never regenerates the header, so it
+# can't clobber hand edits and needs no network access.
+.PHONY: eeprom-check
+eeprom-check:
+	$(QUIET)$(PYTHON) generate_eeprom.py --check
 
 #####################
 # main firmware build

--- a/generate_eeprom.py
+++ b/generate_eeprom.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""
+Keep AM32's Inc/eeprom.h and Inc/eeprom.json in sync.
+
+eeprom.h is the hand-edited source of truth for the EEPROM layout. eeprom.json
+mirrors that layout and adds the metadata (ranges, units, enums, version
+gating) that configurators such as the AM32 Configurator and QGroundControl use
+to build version-aware UIs.
+
+By default this script *checks* that the committed eeprom.h matches what the
+schema describes and writes nothing (used by the eeprom-schema CI job and
+'make eeprom-check'). --write regenerates eeprom.h from the schema instead.
+
+Usage:
+    python generate_eeprom.py                      # check eeprom.h matches eeprom.json (no writes)
+    python generate_eeprom.py --check              # same, explicit
+    python generate_eeprom.py --write              # regenerate eeprom.h from the schema
+    python generate_eeprom.py --url --check        # check against the hosted schema at am32.ca/eeprom
+    python generate_eeprom.py path/to/schema.json  # check against a specific schema file
+"""
+
+import difflib
+import json
+import os
+import sys
+import urllib.request
+from collections import OrderedDict
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SCHEMA_URL = "https://am32.ca/eeprom"
+DEFAULT_SCHEMA = os.path.join(SCRIPT_DIR, "Inc", "eeprom.json")
+OUTPUT_FILE = os.path.join(SCRIPT_DIR, "Inc", "eeprom.h")
+
+# Byte width of each schema type. Array-ish types (reserved, bluejay) carry
+# their length in `size`; scalar multi-byte types must declare a matching `size`.
+TYPE_WIDTH = {
+    'int8': 1, 'uint8': 1, 'bool': 1, 'enum': 1, 'number': 1,
+    'reserved': 1, 'bluejay': 1, 'uint16': 2, 'int16': 2, 'uint32': 4,
+}
+
+
+def load_schema_from_url(url: str) -> dict:
+    """Fetch schema from URL."""
+    with urllib.request.urlopen(url) as response:
+        return json.loads(response.read().decode('utf-8'))
+
+
+def load_schema_from_file(path: str) -> dict:
+    """Load schema from local file."""
+    with open(path, 'r') as f:
+        return json.load(f)
+
+
+def load_schema(source: str) -> dict:
+    """Load schema from a local file path or an http(s) URL."""
+    if source.startswith('http://') or source.startswith('https://'):
+        print(f"Fetching schema from {source}...", file=sys.stderr)
+        return load_schema_from_url(source)
+    return load_schema_from_file(source)
+
+
+def get_c_type(field: dict) -> str:
+    """Map schema type to C type."""
+    field_type = field.get('type', 'uint8')
+    size = field.get('size', 1)
+    if field_type == 'reserved':
+        return 'char' if size > 1 else 'uint8_t'
+    elif field_type in ('bool', 'uint8', 'enum'):
+        return 'uint8_t'
+    elif field_type == 'int8':
+        return 'int8_t'
+    elif field_type == 'uint16':
+        return 'uint16_t'
+    elif field_type == 'number':
+        return 'uint8_t'  # Numbers are stored as uint8 in EEPROM
+    elif field_type == 'bluejay':
+        return 'uint8_t'  # Array type, handled separately
+    return 'uint8_t'
+
+
+def validate_layout(schema: dict) -> None:
+    """Validate that the EEPROM layout is internally consistent.
+
+    Raises ValueError on the first problem found. This guards layout
+    *correctness* (offsets, sizes, struct contiguity) independently of whether
+    eeprom.h and eeprom.json agree with each other.
+    """
+    fields = schema['fields']
+    buffer_size = max(
+        (v.get('bufferSize', v.get('size', 192))
+         for v in schema.get('eepromVersions', {}).values()),
+        default=192,
+    )
+
+    ordered = sorted(fields.items(), key=lambda kv: kv[1]['offset'])
+
+    # Fields must form a gapless, non-overlapping cover starting at offset 0:
+    # the C struct packs members with no implicit gaps, so a gap or overlap
+    # means the declared offsets won't match the real struct layout.
+    prev_end = 0
+    prev_name = None
+    for name, f in ordered:
+        offset = f['offset']
+        size = f.get('size', 1)
+        ftype = f.get('type', 'uint8')
+
+        if offset > prev_end:
+            raise ValueError(
+                f"gap before '{name}': bytes {prev_end}..{offset - 1} are "
+                f"unmapped (cover them with a reserved field)")
+        if offset < prev_end:
+            raise ValueError(
+                f"'{name}' at offset {offset} overlaps '{prev_name}' which "
+                f"ends at {prev_end}")
+        if offset + size > buffer_size:
+            raise ValueError(
+                f"'{name}' [{offset}, {offset + size}) exceeds the "
+                f"{buffer_size}-byte buffer")
+
+        width = TYPE_WIDTH.get(ftype)
+        if width is None:
+            raise ValueError(f"'{name}' has unknown type '{ftype}'")
+        if width > 1 and size != width:
+            raise ValueError(
+                f"'{name}' is type '{ftype}' (width {width}) but declares "
+                f"size {size}")
+
+        prev_end = offset + size
+        prev_name = name
+
+    # Nested structs (cName "prefix.member") are emitted as one contiguous
+    # block, so no field outside the struct may fall within its offset span.
+    groups = OrderedDict()
+    for name, f in ordered:
+        cname = f.get('cName', name)
+        if '.' in cname:
+            groups.setdefault(cname.split('.', 1)[0], []).append(f)
+    for prefix, members in groups.items():
+        start = min(m['offset'] for m in members)
+        end = max(m['offset'] + m.get('size', 1) for m in members)
+        for name, f in ordered:
+            cname = f.get('cName', name)
+            if '.' not in cname and start <= f['offset'] < end:
+                raise ValueError(
+                    f"nested struct '{prefix}' (offsets {start}..{end - 1}) is "
+                    f"interleaved with non-member '{cname}' at {f['offset']}")
+
+
+def generate_header(schema: dict) -> str:
+    """Generate the C header file content."""
+    fields = schema['fields']
+
+    # Sort fields by offset
+    sorted_fields = sorted(
+        [(name, f) for name, f in fields.items()],
+        key=lambda x: x[1]['offset']
+    )
+
+    lines = []
+    lines.append("#include \"main.h\"")
+    lines.append("")
+    lines.append("#pragma once")
+    lines.append("")
+    lines.append("#ifndef EEPROM_H_")
+    lines.append("#define EEPROM_H_")
+    lines.append("")
+    lines.append("typedef union EEprom_u {")
+    lines.append("    struct {")
+
+    # Pre-scan: group nested-struct members (cName "prefix.member") by prefix so
+    # each struct can be emitted as one block when its first member is reached.
+    nested_structs = OrderedDict()
+
+    for name, field in sorted_fields:
+        c_name = field.get('cName', None)
+        if c_name is None:
+            # Convert camelCase to snake_case for C
+            c_name = ''.join(['_' + c.lower() if c.isupper() else c for c in name]).lstrip('_')
+
+        if '.' in c_name:
+            prefix, local_name = c_name.split('.', 1)
+            nested_structs.setdefault(prefix, []).append((name, field, local_name))
+
+    # Process all fields in offset order, handling nested structs
+    processed_structs = set()
+
+    for name, field in sorted_fields:
+        offset = field['offset']
+        size = field.get('size', 1)
+        c_name_raw = field.get('cName', None)
+
+        if c_name_raw is None:
+            c_name_raw = ''.join(['_' + c.lower() if c.isupper() else c for c in name]).lstrip('_')
+
+        # Check if this starts a nested struct
+        if '.' in c_name_raw:
+            prefix = c_name_raw.split('.')[0]
+            if prefix not in processed_structs:
+                processed_structs.add(prefix)
+                # Output the nested struct
+                struct_fields = nested_structs[prefix]
+                lines.append(f"        struct {{")
+                for _, sf, local_name in struct_fields:
+                    sf_size = sf.get('size', 1)
+                    sf_offset = sf['offset']
+                    c_type = get_c_type(sf)
+                    if sf_size > 1:
+                        lines.append(f"            {c_type} {local_name}[{sf_size}]; // {sf_offset}")
+                    else:
+                        lines.append(f"            {c_type} {local_name}; // {sf_offset}")
+                lines.append(f"        }} {prefix};")
+        else:
+            # Regular flat field
+            c_type = get_c_type(field)
+
+            # Handle array types
+            if size > 1:
+                lines.append(f"        {c_type} {c_name_raw}[{size}]; // {offset}")
+            else:
+                lines.append(f"        {c_type} {c_name_raw}; // {offset}")
+
+    # Get max EEPROM buffer size from versions
+    max_size = max(v.get('bufferSize', v.get('size', 192)) for v in schema.get('eepromVersions', {}).values())
+
+    lines.append("    };")
+    lines.append(f"    uint8_t buffer[{max_size}];")
+    lines.append("} EEprom_t;")
+    lines.append("")
+    lines.append("extern EEprom_t eepromBuffer;")
+    lines.append("")
+    lines.append("void read_flash_bin(uint8_t* data, uint32_t add, int out_buff_len);")
+    lines.append("void save_flash_nolib(uint8_t* data, int length, uint32_t add);")
+    lines.append("")
+    lines.append("#endif /* EEPROM_H_ */")
+    lines.append("")
+
+    return '\n'.join(lines)
+
+
+def check_in_sync(generated: str) -> int:
+    """Compare freshly generated header text against the committed eeprom.h.
+
+    Returns a process exit code: 0 when they match, 1 otherwise. Writes nothing.
+    """
+    if not os.path.exists(OUTPUT_FILE):
+        print(f"error: {OUTPUT_FILE} does not exist; run with --write to create it",
+              file=sys.stderr)
+        return 1
+
+    with open(OUTPUT_FILE) as f:
+        committed = f.read()
+
+    if committed == generated:
+        print(f"{os.path.basename(OUTPUT_FILE)} is in sync with eeprom.json")
+        return 0
+
+    diff = difflib.unified_diff(
+        committed.splitlines(keepends=True),
+        generated.splitlines(keepends=True),
+        fromfile="eeprom.h (committed)",
+        tofile="eeprom.json (what the schema describes)",
+    )
+    sys.stderr.writelines(diff)
+    print(
+        "\nerror: eeprom.h and eeprom.json have diverged.\n"
+        "  - If you edited eeprom.h, update eeprom.json to match "
+        "(Claude can do this from the diff above).\n"
+        "  - To regenerate eeprom.h from the schema instead, run: "
+        "python generate_eeprom.py --write",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main():
+    # Parse arguments
+    args = [a for a in sys.argv[1:] if not a.startswith('--')]
+    flags = [a for a in sys.argv[1:] if a.startswith('--')]
+
+    # Determine schema source
+    if '--url' in flags:
+        source = SCHEMA_URL
+    elif args:
+        source = args[0]
+    else:
+        source = DEFAULT_SCHEMA
+
+    schema = load_schema(source)
+
+    try:
+        validate_layout(schema)
+    except ValueError as e:
+        print(f"error: invalid EEPROM layout: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    header_content = generate_header(schema)
+
+    # --write regenerates the header; default is a non-destructive sync check.
+    if '--write' in flags:
+        with open(OUTPUT_FILE, 'w') as f:
+            f.write(header_content)
+        print(f"Wrote {OUTPUT_FILE}")
+        return
+
+    sys.exit(check_in_sync(header_content))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Adds `Inc/eeprom.json` — a version-aware schema describing the ESC EEPROM layout plus the metadata (ranges, units, enums, per-version field reinterpretations) that the AM32 Configurator and QGroundControl need to build version-aware settings UIs — and keeps it in lockstep with the hand-edited `Inc/eeprom.h` via CI. The schema is published to am32.ca on release for downstream consumers.

## Problem

The EEPROM layout and its UI metadata only existed in the C header and in per-tool configurator code, so every consumer re-encoded field offsets, scaling, and version rules by hand. There was no machine-readable source for configurators, and nothing kept the header and any external schema consistent as settings evolved across firmware and EEPROM versions.

## Solution

`eeprom.h` stays the hand-edited source of truth for the layout; `eeprom.json` mirrors that layout and carries the configurator metadata. `generate_eeprom.py` validates the schema layout (gapless, non-overlapping, in-bounds offsets; contiguous nested structs) and checks that the two agree — run by the `eeprom-schema` CI job and `make eeprom-check` — and can regenerate the header with `--write`. A separate release workflow publishes `eeprom.json` to the rolling am32.ca/eeprom URL on each release (the upload transport is stubbed pending the deploy mechanism). Maintainers can keep editing the header by hand and update the JSON afterward; CI flags any divergence.
