### PR TITLE
Add ws2812 driver for l431 (TIM based)

### DIFF
--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -5389,11 +5389,8 @@
 #ifndef LED_BRIGHTNESS
 #define LED_BRIGHTNESS 128
 #endif
-#ifndef LED_COUNT 
+#ifndef LED_COUNT
 #define LED_COUNT 1
-#endif
-#ifndef LED_PROFILE
-#define LED_PROFILE LED_PROFILE_SOLID(0, 255, 0)
 #endif
 #endif
 

--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -39,6 +39,14 @@
 // used to hold a port/pin in a single 16 bit integer
 #define GPIO_PORT_PIN(portnum, pinnum) ((portnum)<<8|(pinnum))
 
+// Disarmed = red. Armed = Green, Spinning = Profile (solid, blink 1 color, blink 2 colors)
+#define LED_MODE_SOLID          0
+#define LED_MODE_BLINK_1_COLOR  1
+#define LED_MODE_BLINK_2_COLOR  2
+#define LED_PROFILE_SOLID(r, g, b) { LED_MODE_SOLID, (uint8_t)(r), (uint8_t)(g), (uint8_t)(b), 0, 0, 0, 0 }
+#define LED_PROFILE_BLINK1(r, g, b, ms) { LED_MODE_BLINK_1_COLOR, (uint8_t)(r), (uint8_t)(g), (uint8_t)(b), 0, 0, 0, (uint16_t)(ms) }
+#define LED_PROFILE_BLINK2(r1, g1, b1, r2, g2, b2, ms) { LED_MODE_BLINK_2_COLOR, (uint8_t)(r1), (uint8_t)(g1), (uint8_t)(b1), (uint8_t)(r2), (uint8_t)(g2), (uint8_t)(b2), (uint16_t)(ms) }
+
 // GLOBAL
 // #define USE_ADC_INPUT
 // #define USE_ALKAS_DEBUG_LED
@@ -4780,6 +4788,12 @@
 #define CURRENT_ADC_CHANNEL         LL_ADC_CHANNEL_8
 #define VOLTAGE_ADC_CHANNEL         LL_ADC_CHANNEL_11
 
+#ifdef USE_LED_STRIP
+#define WS2812_PORT      GPIOB
+#define WS2812_PIN       LL_GPIO_PIN_5
+#define WS2812_AF        LL_GPIO_AF_5
+#endif
+
 #endif
 
 
@@ -4819,12 +4833,16 @@
 #define PHASE_B_COMP LL_COMP_INPUT_MINUS_IO5  // pa5
 #define PHASE_C_COMP LL_COMP_INPUT_MINUS_IO4  // pa4
 #define COMMON_COMP  LL_COMP_INPUT_PLUS_IO1
-//#define USE_LED_STRIP
-//#define WS2812_PIN LL_GPIO_PIN_3
 
 #define CURRENT_ADC_CHANNEL LL_ADC_CHANNEL_8
 #define VOLTAGE_ADC_CHANNEL LL_ADC_CHANNEL_11
 #define ADC_CHANNEL_TEMP LL_ADC_CHANNEL_6
+
+#ifdef USE_LED_STRIP
+#define WS2812_PORT      GPIOB
+#define WS2812_PIN       LL_GPIO_PIN_5
+#define WS2812_AF        LL_GPIO_AF_5
+#endif
 
 #endif
 
@@ -4866,6 +4884,12 @@
 
 #define CURRENT_ADC_CHANNEL         LL_ADC_CHANNEL_8
 #define VOLTAGE_ADC_CHANNEL         LL_ADC_CHANNEL_11
+
+#ifdef USE_LED_STRIP
+#define WS2812_PORT      GPIOB
+#define WS2812_PIN       LL_GPIO_PIN_5
+#define WS2812_AF        LL_GPIO_AF_5
+#endif
 
 #endif
 
@@ -4922,6 +4946,12 @@
 
 #define CURRENT_ADC_CHANNEL         LL_ADC_CHANNEL_8
 #define VOLTAGE_ADC_CHANNEL         LL_ADC_CHANNEL_11
+
+#ifdef USE_LED_STRIP
+#define WS2812_PORT      GPIOB
+#define WS2812_PIN       LL_GPIO_PIN_5
+#define WS2812_AF        LL_GPIO_AF_5
+#endif
 
 #endif
 
@@ -5353,6 +5383,18 @@
 // all DroneCAN ESCs use 128k flash layout
 #undef EEPROM_START_ADD
 #define EEPROM_START_ADD (uint32_t)0x0801F800
+#endif
+
+#ifdef USE_LED_STRIP
+#ifndef LED_BRIGHTNESS
+#define LED_BRIGHTNESS 128
+#endif
+#ifndef LED_COUNT 
+#define LED_COUNT 1
+#endif
+#ifndef LED_PROFILE
+#define LED_PROFILE LED_PROFILE_SOLID(0, 255, 0)
+#endif
 #endif
 
 #ifndef NOMINAL_PWM

--- a/Mcu/l431/Inc/WS2812.h
+++ b/Mcu/l431/Inc/WS2812.h
@@ -3,6 +3,12 @@
 
 #include "main.h"
 
+/* This driver is non-blocking (SPI1 + DMA1 CH3): send_LED_RGB returns
+ * immediately and motor IRQs are not disturbed during the transfer.
+ * main.c gates the LED_PROFILE state machine on this flag so opting
+ * into the profile on a bit-bang driver fails to compile. */
+#define WS2812_NONBLOCKING 1
+
 void WS2812_Init(void);
 void send_LED_RGB(uint8_t red, uint8_t green, uint8_t blue);
 

--- a/Mcu/l431/Inc/WS2812.h
+++ b/Mcu/l431/Inc/WS2812.h
@@ -1,0 +1,9 @@
+#ifndef INC_WS2812_H_
+#define INC_WS2812_H_
+
+#include "main.h"
+
+void WS2812_Init(void);
+void send_LED_RGB(uint8_t red, uint8_t green, uint8_t blue);
+
+#endif /* INC_WS2812_H_ */

--- a/Mcu/l431/Src/WS2812.c
+++ b/Mcu/l431/Src/WS2812.c
@@ -1,0 +1,102 @@
+#include "WS2812.h"
+#include "targets.h"
+
+#ifdef USE_LED_STRIP
+
+#include "stm32l4xx_ll_spi.h"
+
+#if !defined(WS2812_PORT) || !defined(WS2812_PIN) || !defined(WS2812_AF)
+#error "WS2812_PORT / WS2812_PIN / WS2812_AF must be defined by the hardware group"
+#endif
+
+/* SPI1 MOSI driven via DMA1 channel 3 (the only request mapping for
+ * SPI1_TX on L431). The pin/AF come from the hardware group, but every
+ * L4 group points the same place because PB5 (AF5) is the only SPI1_MOSI
+ * pin this part exposes. Clocked at PCLK2 / 32 = 2.5 MHz, each WS2812
+ * bit becomes 3 SPI bits at 400 ns/bit:
+ *   '0' -> 0b100  (400 ns high, 800 ns low)
+ *   '1' -> 0b110  (800 ns high, 400 ns low)
+ * 24 colour bits per LED * 3 = 72 SPI bits = 9 bytes.
+ * 16 trailing zero bytes hold MOSI low for ~51 us, satisfying the
+ * WS2812 reset latch so back-to-back sends still latch correctly. */
+#define WS2812_BYTES_PER_LED 9
+#define WS2812_RESET_BYTES   16
+#define WS2812_BUFFER_BYTES  (LED_COUNT * WS2812_BYTES_PER_LED + WS2812_RESET_BYTES)
+
+static uint8_t led_dma_buffer[WS2812_BUFFER_BYTES];
+
+static void encode_byte(uint8_t in, uint8_t *out)
+{
+    uint32_t acc = 0;
+    for (int b = 7; b >= 0; b--) {
+        acc <<= 3;
+        acc |= ((in >> b) & 1u) ? 0x6u : 0x4u;
+    }
+    out[0] = (uint8_t)(acc >> 16);
+    out[1] = (uint8_t)(acc >> 8);
+    out[2] = (uint8_t)acc;
+}
+
+void WS2812_Init(void)
+{
+    LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOB);
+    LL_GPIO_SetPinMode(WS2812_PORT, WS2812_PIN, LL_GPIO_MODE_ALTERNATE);
+    LL_GPIO_SetAFPin_0_7(WS2812_PORT, WS2812_PIN, WS2812_AF);
+    LL_GPIO_SetPinSpeed(WS2812_PORT, WS2812_PIN, LL_GPIO_SPEED_FREQ_HIGH);
+    LL_GPIO_SetPinOutputType(WS2812_PORT, WS2812_PIN, LL_GPIO_OUTPUT_PUSHPULL);
+    LL_GPIO_SetPinPull(WS2812_PORT, WS2812_PIN, LL_GPIO_PULL_NO);
+
+    LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SPI1);
+
+    /* Master, SSM+SSI (NSS managed in software), BR=/32, CPOL=0/CPHA=0,
+     * MSB-first, half-duplex transmit-only on MOSI so MISO pin is free. */
+    SPI1->CR1 = SPI_CR1_MSTR
+              | SPI_CR1_SSM | SPI_CR1_SSI
+              | SPI_CR1_BR_2
+              | SPI_CR1_BIDIMODE | SPI_CR1_BIDIOE;
+    /* 8-bit data, RX FIFO threshold = 1/4 (byte access), TX DMA enable. */
+    SPI1->CR2 = (7u << SPI_CR2_DS_Pos) | SPI_CR2_FRXTH | SPI_CR2_TXDMAEN;
+
+    LL_DMA_SetPeriphRequest(DMA1, LL_DMA_CHANNEL_3, LL_DMA_REQUEST_1);
+    LL_DMA_SetDataTransferDirection(DMA1, LL_DMA_CHANNEL_3,
+                                    LL_DMA_DIRECTION_MEMORY_TO_PERIPH);
+    LL_DMA_SetChannelPriorityLevel(DMA1, LL_DMA_CHANNEL_3, LL_DMA_PRIORITY_LOW);
+    LL_DMA_SetMode(DMA1, LL_DMA_CHANNEL_3, LL_DMA_MODE_NORMAL);
+    LL_DMA_SetPeriphIncMode(DMA1, LL_DMA_CHANNEL_3, LL_DMA_PERIPH_NOINCREMENT);
+    LL_DMA_SetMemoryIncMode(DMA1, LL_DMA_CHANNEL_3, LL_DMA_MEMORY_INCREMENT);
+    LL_DMA_SetPeriphSize(DMA1, LL_DMA_CHANNEL_3, LL_DMA_PDATAALIGN_BYTE);
+    LL_DMA_SetMemorySize(DMA1, LL_DMA_CHANNEL_3, LL_DMA_MDATAALIGN_BYTE);
+
+    LL_SPI_Enable(SPI1);
+}
+
+void send_LED_RGB(uint8_t red, uint8_t green, uint8_t blue)
+{
+    /* Skip if a transfer is still in flight. The caller's state machine
+     * re-sends on every transition, so the next call will succeed. */
+    if ((DMA1_Channel3->CCR & DMA_CCR_EN) && DMA1_Channel3->CNDTR != 0) {
+        return;
+    }
+    LL_DMA_DisableChannel(DMA1, LL_DMA_CHANNEL_3);
+
+    uint8_t *p = led_dma_buffer;
+    for (uint8_t led = 0; led < LED_COUNT; led++) {
+        encode_byte(green, p); p += 3;
+        encode_byte(red,   p); p += 3;
+        encode_byte(blue,  p); p += 3;
+    }
+    /* Trailing reset window stays zero-initialised in BSS but write it
+     * here too so the buffer survives a warm-restart with leftover data. */
+    for (uint32_t i = 0; i < WS2812_RESET_BYTES; i++) {
+        p[i] = 0;
+    }
+
+    DMA1_Channel3->CMAR  = (uint32_t)led_dma_buffer;
+    DMA1_Channel3->CPAR  = (uint32_t)&SPI1->DR;
+    DMA1_Channel3->CNDTR = WS2812_BUFFER_BYTES;
+    DMA1->IFCR = DMA_IFCR_CGIF3;
+
+    LL_DMA_EnableChannel(DMA1, LL_DMA_CHANNEL_3);
+}
+
+#endif

--- a/Mcu/l431/Src/peripherals.c
+++ b/Mcu/l431/Src/peripherals.c
@@ -12,6 +12,9 @@
 #include "ADC.h"
 #include "serial_telemetry.h"
 #include "targets.h"
+#ifdef USE_LED_STRIP
+#include "WS2812.h"
+#endif
 
 extern char bemf_timeout;
 
@@ -42,6 +45,9 @@ void initCorePeripherals(void)
 #endif
 #ifdef USE_INTERNAL_AMP
      init_OPAMP();
+#endif
+#ifdef USE_LED_STRIP
+    WS2812_Init();
 #endif
 }
 
@@ -738,10 +744,6 @@ void enableCorePeripherals()
     LL_TIM_CC_EnableChannel(IC_TIMER_REGISTER,
         IC_TIMER_CHANNEL); // input capture and output compare
     LL_TIM_EnableCounter(IC_TIMER_REGISTER);
-#endif
-
-#ifdef USE_LED_STRIP
-    send_LED_RGB(255, 0, 0);
 #endif
 
 #ifdef USE_RGB_LED

--- a/Src/main.c
+++ b/Src/main.c
@@ -236,6 +236,9 @@ an settings option)
 
 #ifdef USE_LED_STRIP
 #include "WS2812.h"
+#if defined(LED_PROFILE) && !defined(WS2812_NONBLOCKING)
+#error "LED_PROFILE requires a non-blocking WS2812 driver. The driver for this MCU disables IRQs during send and would degrade motor control. Port the driver to DMA or drop LED_PROFILE."
+#endif
 #endif
 
 #ifdef USE_CRSF_INPUT
@@ -1308,7 +1311,7 @@ if (!stepper_sine && armed) {
 #endif
 }
 
-#ifdef USE_LED_STRIP
+#if defined(USE_LED_STRIP) && defined(LED_PROFILE)
 typedef struct {
     uint8_t  mode;
     uint8_t  c1_r, c1_g, c1_b;
@@ -1332,7 +1335,7 @@ static void send_LED_RGB_scaled(uint8_t r, uint8_t g, uint8_t b)
 
 void tenKhzRoutine()
 { // 20khz as of 2.00 to be renamed
-#ifdef USE_LED_STRIP
+#if defined(USE_LED_STRIP) && defined(LED_PROFILE)
     // 1 kHz ms counter for blink timing -- LED I/O stays in main loop.
     static uint8_t led_subtick = 0;
     if (++led_subtick >= 20) {
@@ -1354,6 +1357,11 @@ void tenKhzRoutine()
                     if (armed_timeout_count > LOOP_FREQUENCY_HZ) { // one second
                         if (zero_input_count > 30) {
                             armed = 1;
+#if defined(USE_LED_STRIP) && !defined(LED_PROFILE)
+                            // Legacy LED flow: one-shot green at arming.
+                            delayMicros(1000);
+                            send_LED_RGB(0, 255, 0);
+#endif
 #ifdef USE_RGB_LED
                             setIndividualRGBLed(0,1,0);
 #endif
@@ -1778,6 +1786,10 @@ int main(void)
     GPIOA->BRR = LL_GPIO_PIN_11;
     GPIOA->BSRR = LL_GPIO_PIN_12;    // Pa12 attached to enable on dev board
 #endif
+#if defined(USE_LED_STRIP) && !defined(LED_PROFILE)
+    // Legacy LED flow: one-shot red at boot.
+    send_LED_RGB(125, 0, 0);
+#endif
 #ifdef USE_RGB_LED
      setIndividualRGBLed(1,0,0);
 #endif
@@ -1863,14 +1875,14 @@ int main(void)
   startup_max_duty_cycle = startup_max_duty_cycle + 400;
 #endif
 
-#ifdef USE_LED_STRIP
+#if defined(USE_LED_STRIP) && defined(LED_PROFILE)
     uint8_t  led_was_running = 0xFF;
     uint8_t  led_was_armed   = 0xFF;
     uint8_t  led_blink_phase = 1;
     uint32_t led_last_ms     = 0;
 #endif
     while (1) {
-#ifdef USE_LED_STRIP
+#if defined(USE_LED_STRIP) && defined(LED_PROFILE)
         char led_dirty = 0;
         if (running != led_was_running || armed != led_was_armed) {
             led_was_running = running;

--- a/Src/main.c
+++ b/Src/main.c
@@ -1308,8 +1308,39 @@ if (!stepper_sine && armed) {
 #endif
 }
 
+#ifdef USE_LED_STRIP
+typedef struct {
+    uint8_t  mode;
+    uint8_t  c1_r, c1_g, c1_b;
+    uint8_t  c2_r, c2_g, c2_b;
+    uint16_t blink_delay_ms;
+} led_profile_t;
+
+static const led_profile_t armed_profile = LED_PROFILE;
+
+volatile uint8_t  led_brightness = LED_BRIGHTNESS;
+volatile uint32_t led_ms_counter = 0;
+
+static void send_LED_RGB_scaled(uint8_t r, uint8_t g, uint8_t b)
+{
+    r = (uint16_t)r * led_brightness / 255;
+    g = (uint16_t)g * led_brightness / 255;
+    b = (uint16_t)b * led_brightness / 255;
+    send_LED_RGB(r, g, b);
+}
+#endif
+
 void tenKhzRoutine()
 { // 20khz as of 2.00 to be renamed
+#ifdef USE_LED_STRIP
+    // 1 kHz ms counter for blink timing -- LED I/O stays in main loop.
+    static uint8_t led_subtick = 0;
+    if (++led_subtick >= 20) {
+        led_subtick = 0;
+        led_ms_counter++;
+    }
+#endif
+
     duty_cycle = duty_cycle_setpoint;
     tenkhzcounter++;
     ledcounter++;
@@ -1323,11 +1354,6 @@ void tenKhzRoutine()
                     if (armed_timeout_count > LOOP_FREQUENCY_HZ) { // one second
                         if (zero_input_count > 30) {
                             armed = 1;
-#ifdef USE_LED_STRIP
-                            //	send_LED_RGB(0,0,0);
-                            delayMicros(1000);
-                            send_LED_RGB(0, 255, 0);
-#endif
 #ifdef USE_RGB_LED
                             setIndividualRGBLed(0,1,0);
 #endif
@@ -1752,9 +1778,6 @@ int main(void)
     GPIOA->BRR = LL_GPIO_PIN_11;
     GPIOA->BSRR = LL_GPIO_PIN_12;    // Pa12 attached to enable on dev board
 #endif
-#ifdef USE_LED_STRIP
-    send_LED_RGB(125, 0, 0);
-#endif
 #ifdef USE_RGB_LED
      setIndividualRGBLed(1,0,0);
 #endif
@@ -1840,7 +1863,42 @@ int main(void)
   startup_max_duty_cycle = startup_max_duty_cycle + 400;
 #endif
 
+#ifdef USE_LED_STRIP
+    uint8_t  led_was_running = 0xFF;
+    uint8_t  led_was_armed   = 0xFF;
+    uint8_t  led_blink_phase = 1;
+    uint32_t led_last_ms     = 0;
+#endif
     while (1) {
+#ifdef USE_LED_STRIP
+        char led_dirty = 0;
+        if (running != led_was_running || armed != led_was_armed) {
+            led_was_running = running;
+            led_was_armed   = armed;
+            led_blink_phase = 1;
+            led_last_ms     = led_ms_counter;
+            led_dirty       = 1;
+        }
+        if (running && armed_profile.mode != LED_MODE_SOLID &&
+            (led_ms_counter - led_last_ms) >= armed_profile.blink_delay_ms) {
+            led_last_ms      = led_ms_counter;
+            led_blink_phase ^= 1;
+            led_dirty        = 1;
+        }
+        if (led_dirty) {
+            if (!armed) {
+                send_LED_RGB_scaled(255, 0, 0);
+            } else if (!running) {
+                send_LED_RGB_scaled(0, 255, 0);
+            } else if (armed_profile.mode == LED_MODE_BLINK_1_COLOR && !led_blink_phase) {
+                send_LED_RGB_scaled(0, 0, 0);
+            } else if (armed_profile.mode == LED_MODE_BLINK_2_COLOR && !led_blink_phase) {
+                send_LED_RGB_scaled(armed_profile.c2_r, armed_profile.c2_g, armed_profile.c2_b);
+            } else {
+                send_LED_RGB_scaled(armed_profile.c1_r, armed_profile.c1_g, armed_profile.c1_b);
+            }
+        }
+#endif
 e_com_time = ((commutation_intervals[0] + commutation_intervals[1] + commutation_intervals[2] + commutation_intervals[3] + commutation_intervals[4] + commutation_intervals[5]) + 4) >> 1; // COMMUTATION INTERVAL IS 0.5US INCREMENTS
 #if defined(FIXED_DUTY_MODE) || defined(FIXED_SPEED_MODE)
         setInput();


### PR DESCRIPTION
Adds non-blocking WS2812 driver for L431 (SPI1+DMA on PB5) and a profile-driven LED statemachine (red disarmed / green armed-idle / `LED_PROFILE` spinning).

Profile let's user set `SOLID`, `BLINK1` (one color),`BLINK2` (two colors). This let's the drone lights comply to regulation for those who need it.

Opt-in via `LED_PROFILE`; existing targets without it keep their original boot-red / arm-green behaviour unchanged. A `WS2812_NONBLOCKING` flag in each MCU's `WS2812.h` plus a `#error` in `main.c` makes it a build failure to enable the profile on an MCU whose driver would block IRQs.
The bitbang implementation in many targets affect motor performance (verified) due to the disabling of IRQ for a short period, causing missed cycles of control during LED changes.

Hardware-tested on `L431_A`, video demo:
https://github.com/user-attachments/assets/49e216c2-80be-4c67-9f5c-d5f4552666fa

**Notes:**
- `USE_RGB_LED` (the discrete tri-colour LED feature) is untouched and can coexist with `USE_LED_STRIP` on any MCU where they don't share a pin. On L431 both would claim PB5, so the driver errors in build if both are defined.

**Open questions**
- Syncing multiple ESCs to blink at the same time and over long periods of time. Slight clock drift will make them drift. CAN frame, DSHOT / PWM flank could perhaps be used to align. However only CAN frame is recieved at the same time on multiple ESCs.
- The color, profile etc. could be setable parameters over e.g CAN
- Is "profile" during spinning the correct way to do it? Keeping the startup (red) + arm (green) behavior and only adding profile.