### PR TITLE
telemetry(v203): use USART TC IRQ to release bus after DMA TX

### DIFF
--- a/Mcu/v203/Src/ch32v20x_it.c
+++ b/Mcu/v203/Src/ch32v20x_it.c
@@ -49,6 +49,8 @@ void EXTI4_IRQHandler(void)  __attribute__((interrupt("WCH-Interrupt-fast")));
 #endif
 //for tele DMA
 void DMA1_Channel7_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+//for USART2
+void USART2_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
 //for com
 void TIM3_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
 //dor dshot
@@ -134,10 +136,15 @@ void DMA1_Channel7_IRQHandler(void)
 {
     if(DMA_GetITStatus(DMA1_IT_TC7))
     {
-        USART_DMACmd(USART2,USART_DMAReq_Tx,DISABLE);
+        /* DMA transfer complete: stop DMA requests and channel, then
+         * enable USART Transmission Complete (TC) interrupt so we wait
+         * for the actual end of frame on the UART before disabling TX/DE.
+         */
+        USART_DMACmd(USART2, USART_DMAReq_Tx, DISABLE);
         DMA_Cmd(DMA1_Channel7, DISABLE);
-        MODIFY_REG(USART2->CTLR1, 0x3<<2, 0x0<<3);  //disable send
         DMA_ClearFlag(DMA1_IT_TC7);
+        USART_ClearFlag(USART2, USART_FLAG_TC);
+        USART_ITConfig(USART2, USART_IT_TC, ENABLE);
     }
     /* Check whether DMA transfer error caused the DMA interruption */
     if(DMA_GetITStatus(DMA1_IT_TE7))
@@ -146,6 +153,23 @@ void DMA1_Channel7_IRQHandler(void)
         MODIFY_REG(USART2->CTLR1, 0x3<<2, 0x0<<3);  //disable send
         DMA_Cmd(DMA1_Channel7, DISABLE);
         DMA_ClearFlag(DMA1_IT_TE7);
+    }
+}
+
+void USART2_IRQHandler(void)
+{
+    if(USART_GetITStatus(USART2, USART_IT_TC))
+    {
+        /* Clear TC pending and disable transmitter/DE here */
+        USART_ClearFlag(USART2, USART_FLAG_TC);
+        /* Disable transmitter (clear TE). Leave RE unchanged. */
+        MODIFY_REG(USART2->CTLR1, USART_CTLR1_TE, 0x0);
+        USART_ITConfig(USART2, USART_IT_TC, DISABLE);
+        GPIO_InitTypeDef  GPIO_InitStruct = {0};
+        GPIO_InitStruct.GPIO_Pin = GPIO_Pin_2;
+        GPIO_InitStruct.GPIO_Speed = GPIO_Speed_50MHz;
+        GPIO_InitStruct.GPIO_Mode = GPIO_Mode_IPU;
+        GPIO_Init(GPIOA, &GPIO_InitStruct);
     }
 }
 

--- a/Mcu/v203/Src/serial_telemetry.c
+++ b/Mcu/v203/Src/serial_telemetry.c
@@ -46,7 +46,11 @@ void telem_UART_Init(void)
     USART_InitStruct.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
     USART_Init(USART2, &USART_InitStruct);
     USART_Cmd(USART2, ENABLE);
-
+    
+    /* Clear any pending TC and enable USART2 IRQ so TC interrupt can fire */
+    USART_ClearFlag(USART2, USART_FLAG_TC);
+    NVIC_SetPriority(USART2_IRQn, 0xE0);
+    NVIC_EnableIRQ(USART2_IRQn);
 
     /* USART2 DMA Init */
     DMA_DeInit(DMA1_Channel7);


### PR DESCRIPTION
Problem: 
Last telemetry byte gets cut off when disabling TX/DE on DMA TC.

Solution: 
In DMA TC IRQ: stop DMA requests/channel, clear DMA TC flag, clear USART TC flag, then enable USART_IT_TC.
Implement USART2_IRQHandler: on USART_FLAG_TC clear the flag, disable transmitter (TE/DE) and disable the TC IRQ.
In UART init: clear USART_FLAG_TC and enable USART2_IRQn so the TC IRQ can fire.

Result: 
TX/DE are released only after the UART has physically finished sending the last bit, preventing the last-byte cut-off.

Oscilloscope:
before:
<img width="1024" height="600" alt="before_patch" src="https://github.com/user-attachments/assets/60027aa0-0103-455e-97ff-162464153d5d" />
after:
<img width="1024" height="600" alt="after_patch" src="https://github.com/user-attachments/assets/67c5c11e-effd-49bc-b1d5-5b08c7383734" />
