### PR TITLE
fix(dronecan): clamp ESC_INDEX parameter to 31 to match 5-bit telemetry field

### DIFF
--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -133,7 +133,7 @@ static const struct parameter {
         // list of settable parameters
         // dronecan specific parameters
         { "CAN_NODE",               T_UINT8, 0, 127, 0, &eepromBuffer.can.can_node},
-        { "ESC_INDEX",              T_UINT8, 0, 32,  0, &eepromBuffer.can.esc_index},
+        { "ESC_INDEX",              T_UINT8, 0, 31,  0, &eepromBuffer.can.esc_index},
         { "TELEM_RATE",             T_UINT8, 0, 200, 25, &eepromBuffer.can.telem_rate},
         { "DEBUG_RATE",             T_UINT8, 0, 200, 0, &eepromBuffer.can.debug_rate},
         { "REQUIRE_ARMING",         T_BOOL,  0, 1,   1, &eepromBuffer.can.require_arming},


### PR DESCRIPTION
## Summary
The DroneCAN `ESC_INDEX` parameter accepts a maximum of 32, but `esc_index` is transmitted as a 5-bit field in the ESC `Status` and `StatusExtended` telemetry messages, which can only represent 0–31. This clamps the parameter to 31.

## Problem
The stored `esc_index` byte flows verbatim into the 5-bit wire field (`canardEncodeScalar(buffer, *bit_ofs, 5, &msg->esc_index)`). A configured value of 32 (`0b100000`) truncates to 0 on the bus, so an ESC set to index 32 reports telemetry as index 0 and collides with the first ESC. `load_settings()` clamps the stored byte to the parameter's `[min, max]`, so the table's `max = 32` is the only thing letting the unrepresentable value through.

## Solution
Set the `ESC_INDEX` parameter maximum to 31, matching the telemetry field width. The `Inc/eeprom.json` schema (#295) already uses 0–31.