### PR TITLE
fix(current-limit): apply the limit at raw 100 (200 A) instead of disabling it

### DIFF
--- a/Src/main.c
+++ b/Src/main.c
@@ -721,7 +721,7 @@ void loadEEpromSettings()
             eepromBuffer.limits.temperature = 255;
         }
 
-        if (eepromBuffer.limits.current > 0 && eepromBuffer.limits.current < 100) {
+        if (eepromBuffer.limits.current > 0 && eepromBuffer.limits.current <= 100) {
             use_current_limit = 1;
         }
         


### PR DESCRIPTION
## Summary
Draft for maintainer confirmation. Current limiting is enabled only when the stored value is strictly less than 100, so the maximum configurable limit — raw 100, i.e. 200 A — silently disables limiting instead of applying it. This proposes making 100 inclusive.

## Problem
The DroneCAN `CURRENT_LIMIT` parameter is documented as 0–200 A with "0 to disable" and is stored as amps/2, so 200 A is stored as raw 100. But `loadEEpromSettings()` enables limiting only when `limits.current > 0 && limits.current < 100`, so a user who sets 200 A gets no current limit at all — raw 0 (disabled) and raw 100 (max) behave identically.

## Solution
Change the upper bound to `<= 100` so raw 1–100 (2–200 A) enable limiting and only raw 0 disables it. Marked draft pending confirmation from Alka on the intended meaning of raw 100: is it the maximum active limit, or a reserved sentinel? If it is intended as a sentinel, the `Inc/eeprom.json` schema (which now treats raw 100 as 200 A) should change instead of the firmware.