### PR TITLE
f421: honor USE_PA14_TELEMETRY for serial telemetry

### DIFF
--- a/Mcu/f421/Src/serial_telemetry.c
+++ b/Mcu/f421/Src/serial_telemetry.c
@@ -7,7 +7,61 @@
 
 #include "serial_telemetry.h"
 #include "common.h"
+#include "targets.h"
 #include "kiss_telemetry.h"
+
+#ifdef USE_PA14_TELEMETRY
+
+void send_telem_DMA(uint8_t bytes)
+{ // set data length and enable channel to start transfer
+    DMA1_CHANNEL4->ctrl_bit.chen = FALSE;
+    DMA1_CHANNEL4->dtcnt = bytes;
+    DMA1_CHANNEL4->ctrl_bit.chen = TRUE;
+}
+
+void telem_UART_Init(void)
+{
+    gpio_init_type gpio_init_struct;
+
+    crm_periph_clock_enable(CRM_USART2_PERIPH_CLOCK, TRUE);
+    crm_periph_clock_enable(CRM_GPIOA_PERIPH_CLOCK, TRUE);
+    crm_periph_clock_enable(CRM_DMA1_PERIPH_CLOCK, TRUE);
+
+    /* configure the usart2 tx pin on PA14 (SWCLK/TLM) */
+    gpio_init_struct.gpio_drive_strength = GPIO_DRIVE_STRENGTH_STRONGER;
+    gpio_init_struct.gpio_out_type = GPIO_OUTPUT_PUSH_PULL;
+    gpio_init_struct.gpio_mode = GPIO_MODE_MUX;
+    gpio_init_struct.gpio_pins = GPIO_PINS_14;
+    gpio_init_struct.gpio_pull = GPIO_PULL_UP;
+    gpio_init(GPIOA, &gpio_init_struct);
+    gpio_pin_mux_config(GPIOA, GPIO_PINS_SOURCE14, GPIO_MUX_1);
+
+    dma_reset(DMA1_CHANNEL4);
+
+    dma_init_type dma_init_struct;
+    dma_default_para_init(&dma_init_struct);
+    dma_init_struct.buffer_size = sizeof(aTxBuffer);
+    dma_init_struct.direction = DMA_DIR_MEMORY_TO_PERIPHERAL;
+    dma_init_struct.memory_base_addr = (uint32_t)aTxBuffer;
+    dma_init_struct.memory_data_width = DMA_MEMORY_DATA_WIDTH_BYTE;
+    dma_init_struct.memory_inc_enable = TRUE;
+    dma_init_struct.peripheral_base_addr = (uint32_t)&USART2->dt;
+    dma_init_struct.peripheral_data_width = DMA_PERIPHERAL_DATA_WIDTH_BYTE;
+    dma_init_struct.peripheral_inc_enable = FALSE;
+    dma_init_struct.priority = DMA_PRIORITY_LOW;
+    dma_init_struct.loop_mode_enable = FALSE;
+    dma_init(DMA1_CHANNEL4, &dma_init_struct);
+
+    /* configure usart2 param */
+    usart_init(USART2, 115200, USART_DATA_8BITS, USART_STOP_1_BIT);
+    usart_transmitter_enable(USART2, TRUE);
+    usart_receiver_enable(USART2, TRUE);
+    usart_single_line_halfduplex_select(USART2, TRUE);
+    usart_dma_transmitter_enable(USART2, TRUE);
+    usart_enable(USART2, TRUE);
+}
+
+#else
 
 void send_telem_DMA(uint8_t bytes)
 { // set data length and enable channel to start transfer
@@ -62,3 +116,5 @@ void telem_UART_Init(void)
 
     nvic_irq_enable(DMA1_Channel3_2_IRQn, 3, 0);
 }
+
+#endif


### PR DESCRIPTION
# Fix F421 serial telemetry routing for `USE_PA14_TELEMETRY`

## Summary

This change fixes a mismatch in the AT32F421 serial telemetry implementation.

Several F421 targets in `Inc/targets.h` explicitly define:

```c
#define USE_PA14_TELEMETRY
```

However, `Mcu/f421/Src/serial_telemetry.c` previously hardcoded serial telemetry to:

- `PB6`
- `USART1`

This means the implementation did not follow the target definition.

## Problem

For targets such as:

- `F4A_4IN1_F421`
- `FLYWOO_F4A_F421`
- `LUX_G4_HD_AIO_F421`
- `TEKKO32_4IN1_MINI_F421`
- other F421 targets that define `USE_PA14_TELEMETRY`

serial telemetry is intended to be routed through `PA14`.

On affected hardware, schematics also indicate telemetry/TLM on `PA14` (often labeled `SWCLK/TLM`).

But before this patch, the F421 implementation still initialized telemetry output on `PB6 / USART1`, which can result in:

- no serial telemetry output on the expected TLM pad
- target definition not matching actual runtime behavior
- confusion when hardware schematics and firmware target config appear correct

## What this PR changes

When `USE_PA14_TELEMETRY` is defined for F421 targets, `Mcu/f421/Src/serial_telemetry.c` now uses:

- `PA14`
- `USART2`
- `DMA1_CHANNEL4`

instead of the previous hardcoded `PB6 / USART1` path.

Targets that do **not** define `USE_PA14_TELEMETRY` continue to use the original:

- `PB6`
- `USART1`
- `DMA1_CHANNEL2`

So the change is scoped only to F421 targets that explicitly opt into PA14 telemetry.

## Why this is safe

- The change only affects the `f421` MCU implementation.
- The new logic is gated by `#ifdef USE_PA14_TELEMETRY`.
- Existing F421 targets without `USE_PA14_TELEMETRY` keep their original behavior.
- Other MCU families (`f051`, `f415`, `g031`, `g071`, etc.) are untouched.
- `PA14 -> USART2_TX` is supported by the AT32F421 pin mux.
- `USART2_TX -> DMA1_CHANNEL4` is supported by the AT32F421 DMA mapping.

## Motivation

This change was motivated by investigation of a real hardware case where:

- the ESC schematic showed `PA14 = SWCLK/TLM`
- the target definition enabled `USE_PA14_TELEMETRY`
- but no telemetry was observed on the TLM pad

Further review showed that the F421 telemetry implementation was not honoring the target definition.

## Notes

This PR does **not** attempt to solve all board-specific telemetry routing issues.

It only fixes the inconsistency between:

- F421 target definitions using `USE_PA14_TELEMETRY`
- and the F421 telemetry implementation that previously ignored that define

If any F421 target defines `USE_PA14_TELEMETRY` incorrectly for its hardware, that target definition should be corrected separately.

## Suggested testing

Please test at least one F421 target with `USE_PA14_TELEMETRY`, for example:

- `F4A_4IN1_F421`

Expected result:

- serial telemetry output appears on the hardware TLM pad routed from `PA14`
- telemetry can be received by the FC at `115200 8N1`

It would also be useful to verify that a F421 target **without** `USE_PA14_TELEMETRY` still behaves unchanged on `PB6 / USART1`.
