### PR TITLE
perf: reduce CPU load on F051 (and other low-end MCUs)

### DIFF
--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -5579,3 +5579,14 @@
 #ifndef POLLING_MODE_THRESHOLD
 #define POLLING_MODE_THRESHOLD 2000
 #endif
+
+// Place hot functions in RAM on MCUs that execute flash with wait states and
+// have spare RAM. The F051 runs flash at 1WS, RAM at 0WS, so commutation and
+// PWM interrupt code runs noticeably faster from RAM. The .ramfunc input
+// section is placed inside .data so the startup data-init copy loads it.
+// noclone keeps LTO constant-propagation clones from escaping the section.
+#ifdef MCU_F051
+#define RAM_FUNC __attribute__((section(".ramfunc"), noclone))
+#else
+#define RAM_FUNC
+#endif

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,11 @@ FIRMWARE_VERSION := $(VERSION_MAJOR).$(VERSION_MINOR)
 CFLAGS_BASE := -fsingle-precision-constant -fomit-frame-pointer -ffast-math
 CFLAGS_BASE += -I$(MAIN_INC_DIR) -g3 -O3 -ffunction-sections --specs=nosys.specs
 CFLAGS_BASE += -Wall -Wundef -Wextra -Werror -Wno-unused-parameter -Wno-stringop-truncation
+# link time optimization, inlines across translation units which matters a lot
+# on cortex-m0 where call overhead is high, the whole firmware is compiled and
+# linked in one compiler invocation so this needs no other build changes. An
+# mcu makefile can opt out with LTO_FLAGS_<MCU> := (empty) if flash is tight.
+$(foreach MCU,$(MCU_TYPES),$(eval LTO_FLAGS_$(MCU) ?= -flto))
 
 CFLAGS_COMMON := $(CFLAGS_BASE)
 
@@ -105,8 +110,11 @@ $$($(2)_BASENAME).bin: $$($(2)_BASENAME).elf
 $(eval xLDSCRIPT := $$(if $$(call has_can_suffix,$$(2)),$(LDSCRIPT_CAN_$(1)),$(LDSCRIPT_$(1))))
 $(eval xCFLAGS := $$(if $$(call has_can_suffix,$$(2)),$(CFLAGS_CAN_$(1))))
 $(eval xSRC := $$(if $$(call has_can_suffix,$$(2)),$(SRC_CAN_$(1))))
+# no LTO for DroneCAN builds, gcc 10 LTO trips -Werror=maybe-uninitialized
+# false positives in the canard/dsdl code and CAN targets have ample flash
+$(eval xLTO := $$(if $$(call has_can_suffix,$$(2)),,$(LTO_FLAGS_$(1))))
 
-CFLAGS_$(2) = -DAM32_MCU=\"$(MCU)\" $(MCU_$(1)) -D$(2) $(CFLAGS_$(1)) $(CFLAGS_COMMON) $(xCFLAGS)
+CFLAGS_$(2) = -DAM32_MCU=\"$(MCU)\" $(MCU_$(1)) -D$(2) $(CFLAGS_$(1)) $(CFLAGS_COMMON) $(xLTO) $(xCFLAGS)
 LDFLAGS_$(2) = $(LDFLAGS_COMMON) $(LDFLAGS_$(1)) -T$(xLDSCRIPT)
 
 -include $$($(2)_BASENAME).d

--- a/Mcu/a153/Src/DMA.c
+++ b/Mcu/a153/Src/DMA.c
@@ -12,8 +12,7 @@ extern uint16_t ADCDataDMA[];
 extern uint8_t buffersize;
 extern uint32_t dma_buffer[64];
 
-//extern int8_t aTxBuffer[10];
-extern int8_t aTxBuffer[18];
+extern uint8_t aTxBuffer[49];
 extern uint8_t nbDataToTransmit;
 
 /*

--- a/Mcu/f051/Inc/comparator.h
+++ b/Mcu/f051/Inc/comparator.h
@@ -24,7 +24,15 @@
 void maskPhaseInterrupts();
 void changeCompInput();
 void enableCompInterrupts();
-uint8_t getCompOutputLevel();
+
+extern COMP_TypeDef* active_COMP;
+
+// read the comparator output level inline, this is called up to
+// filter_level times per zero cross so call overhead matters
+static inline uint8_t getCompOutputLevel(void)
+{
+    return LL_COMP_ReadOutputLevel(active_COMP);
+}
 
 extern volatile char rising;
 extern char step;

--- a/Mcu/f051/STM32F051K6TX_FLASH.ld
+++ b/Mcu/f051/STM32F051K6TX_FLASH.ld
@@ -136,16 +136,18 @@ SECTIONS
   _sidata = LOADADDR(.data);
 
   /* Initialized data sections into "RAM" Ram type memory */
-  .data : 
+  .data :
   {
     . = ALIGN(4);
     _sdata = .;        /* create a global symbol at data start */
+    *(.ramfunc)        /* functions executed from RAM, copied by startup data init */
+    *(.ramfunc*)
     *(.data)           /* .data sections */
     *(.data*)          /* .data* sections */
 
     . = ALIGN(4);
     _edata = .;        /* define a global symbol at data end */
-    
+
   } >RAM AT> FLASH
 
   /* Uninitialized data section into "RAM" Ram type memory */

--- a/Mcu/f051/Src/comparator.c
+++ b/Mcu/f051/Src/comparator.c
@@ -11,17 +11,15 @@
 
 COMP_TypeDef* active_COMP = COMP1;
 
-uint8_t getCompOutputLevel() { return LL_COMP_ReadOutputLevel(active_COMP); }
-
-void maskPhaseInterrupts()
+RAM_FUNC void maskPhaseInterrupts()
 {
   EXTI->IMR &= ~(1 << 21);
   EXTI->PR = EXTI_LINE;
 }
 
-void enableCompInterrupts() { EXTI->IMR |= (1 << 21); }
+RAM_FUNC void enableCompInterrupts() { EXTI->IMR |= (1 << 21); }
 
-void changeCompInput()
+RAM_FUNC void changeCompInput()
 {
 
 if((average_interval < 400)){

--- a/Mcu/f051/Src/peripherals.c
+++ b/Mcu/f051/Src/peripherals.c
@@ -62,11 +62,11 @@ void initAfterJump(void)
         ((SYSCFG_TypeDef*)(((uint32_t)0x40000000U) + 0x00010000))->CFGR1 |= ((0x1U << (0U)) | (0x2U << (0U)));
     } while (0);
 
-    if (SysTick_Config(SystemCoreClock / 1000)) {
-        /* Capture error */
-        while (1) {
-        }
-    }
+    // keep the SysTick counter running for anything that polls it but do not
+    // enable its interrupt, the handler is empty and just burns cycles at 1khz
+    SysTick->LOAD = (SystemCoreClock / 1000) - 1;
+    SysTick->VAL = 0;
+    SysTick->CTRL = SysTick_CTRL_CLKSOURCE_Msk | SysTick_CTRL_ENABLE_Msk;
     __enable_irq();
 }
 

--- a/Mcu/f051/Src/phaseouts.c
+++ b/Mcu/f051/Src/phaseouts.c
@@ -292,7 +292,7 @@ void allOff()
     phaseCFLOAT();
 }
 
-void comStep(char newStep)
+RAM_FUNC void comStep(char newStep)
 {
     switch (newStep) {
     case 1: // A-B

--- a/Mcu/f051/Src/stm32f0xx_it.c
+++ b/Mcu/f051/Src/stm32f0xx_it.c
@@ -189,7 +189,7 @@ void DMA1_Channel4_5_IRQHandler(void)
  * @brief This function handles ADC and COMP interrupts (COMP interrupts
  * through EXTI lines 21 and 22).
  */
-void ADC1_COMP_IRQHandler(void)
+RAM_FUNC void ADC1_COMP_IRQHandler(void)
 {
   if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_21) != RESET) {
       if((INTERVAL_TIMER->CNT) > ((average_interval>>1))){
@@ -206,7 +206,7 @@ void ADC1_COMP_IRQHandler(void)
 /**
  * @brief This function handles TIM6 global and DAC underrun error interrupts.
  */
-void TIM6_DAC_IRQHandler(void)
+RAM_FUNC void TIM6_DAC_IRQHandler(void)
 {
     if (LL_TIM_IsActiveFlag_UPDATE(TIM6) == 1) {
         LL_TIM_ClearFlag_UPDATE(TIM6);
@@ -217,7 +217,7 @@ void TIM6_DAC_IRQHandler(void)
 /**
  * @brief This function handles TIM14 global interrupt.
  */
-void TIM14_IRQHandler(void)
+RAM_FUNC void TIM14_IRQHandler(void)
 {
     LL_TIM_ClearFlag_UPDATE(TIM14);
     PeriodElapsedCallback();

--- a/Mcu/g431/Src/stm32g4xx_it.c
+++ b/Mcu/g431/Src/stm32g4xx_it.c
@@ -19,7 +19,7 @@ extern volatile char dshot_telemetry;
 extern volatile char armed;
 extern volatile char out_put;
 extern volatile uint8_t compute_dshot_flag;
-extern volatile uint16_t commutation_interval;
+extern volatile uint32_t commutation_interval;
 
 int interrupt = 0;
 

--- a/Src/dshot.c
+++ b/Src/dshot.c
@@ -15,8 +15,6 @@
 #include "DroneCAN/DroneCAN.h"
 #endif
 
-int dpulse[16] = { 0 };
-
 const char gcr_encode_table[16] = {
     0b11001, 0b11011, 0b10010, 0b10011, 0b11101, 0b10101, 0b10110, 0b10111,
     0b11010, 0b01001, 0b01010, 0b01011, 0b11110, 0b01101, 0b01110, 0b01111
@@ -48,7 +46,6 @@ char EDT_ARM_ENABLE = 0;
 char EDT_ARMED = 0;
 int shift_amount = 0;
 volatile uint32_t gcrnumber;
-extern int zero_crosses;
 extern volatile char send_telemetry;
 extern uint8_t max_duty_cycle_change;
 int dshot_full_number;
@@ -75,14 +72,16 @@ void computeDshotDMA()
     halfpulsetime = dshot_frametime >> 5;
     if ((dshot_frametime > dshot_frametime_low) && (dshot_frametime < dshot_frametime_high)) {
 			signaltimeout = 0;
+        // pack the 16 pulses into one word msb first, bit (15 - i) is pulse i
+        uint16_t frame = 0;
         for (int i = 0; i < 16; i++) {
             // note that dma_buffer[] is uint32_t, we cast the difference to uint16_t to handle
             // timer wrap correctly
             const uint16_t pdiff = dma_buffer[(i << 1) + 1] - dma_buffer[(i << 1)];
-            dpulse[i] = (pdiff > halfpulsetime);
+            frame = (frame << 1) | (pdiff > halfpulsetime);
         }
-        uint8_t calcCRC = ((dpulse[0] ^ dpulse[4] ^ dpulse[8]) << 3 | (dpulse[1] ^ dpulse[5] ^ dpulse[9]) << 2 | (dpulse[2] ^ dpulse[6] ^ dpulse[10]) << 1 | (dpulse[3] ^ dpulse[7] ^ dpulse[11]));
-        uint8_t checkCRC = (dpulse[12] << 3 | dpulse[13] << 2 | dpulse[14] << 1 | dpulse[15]);
+        uint8_t calcCRC = ((frame >> 4) ^ (frame >> 8) ^ (frame >> 12)) & 0xF;
+        uint8_t checkCRC = frame & 0xF;
 
         if (!armed) {
             if (dshot_telemetry == 0) {
@@ -96,15 +95,15 @@ void computeDshotDMA()
             }
         }
         if (dshot_telemetry) {
-            checkCRC = ~checkCRC + 16;
+            checkCRC = (~checkCRC) & 0xF;
         }
 
-        int tocheck = (dpulse[0] << 10 | dpulse[1] << 9 | dpulse[2] << 8 | dpulse[3] << 7 | dpulse[4] << 6 | dpulse[5] << 5 | dpulse[6] << 4 | dpulse[7] << 3 | dpulse[8] << 2 | dpulse[9] << 1 | dpulse[10]);
+        int tocheck = frame >> 5; // upper 11 bits are the throttle / command value
 
         if (calcCRC == checkCRC) {
             signaltimeout = 0;
             dshot_goodcounts++;
-            if (dpulse[11] == 1) {
+            if (frame & 0x10) { // telemetry request bit
                 send_telemetry = 1;
             }
             if(programming_mode > 0){  

--- a/Src/main.c
+++ b/Src/main.c
@@ -344,7 +344,7 @@ uint16_t low_cell_volt_cutoff = 330; // 3.3volts per cell
 
 //=========================== END EEPROM Defaults ===========================
 
-const char filename[30] __attribute__((section(".file_name"))) = FILE_NAME;
+const char filename[30] __attribute__((used, section(".file_name"))) = FILE_NAME; // used: keep under LTO
 _Static_assert(sizeof(FIRMWARE_NAME) <=13,"Firmware name too long");   // max 12 character firmware name plus NULL 
 
 // move these to targets folder or peripherals for each mcu
@@ -370,6 +370,7 @@ uint32_t desync_happened = 0;
 uint8_t desync_happened = 0;
 #endif
 char maximum_throttle_change_ramp = 1;
+uint8_t input_priority_is_high = 0xFF; // unknown at boot, first main loop pass sets it
 
 char crawler_mode = 0; // no longer used //
 uint16_t velocity_count = 0;
@@ -419,6 +420,12 @@ char desync_check = 0;
 char low_kv_filter_level = 20;
 
 uint16_t tim1_arr = TIM1_AUTORELOAD; // current auto reset value
+// Q16 fixed point scale factor equal to tim1_arr / 2000, recomputed in the main
+// loop when tim1_arr changes so the 20khz routine multiplies instead of divides
+uint32_t pwm_to_arr_scale_q16 = ((uint32_t)TIM1_AUTORELOAD << 16) / 2000;
+// Q16 input to duty cycle slopes, computed once at startup for setInput
+uint32_t throttle_duty_slope_q16 = ((uint32_t)(2000 - DEAD_TIME) << 16) / (2047 - 47);
+uint32_t sine_throttle_duty_slope_q16 = ((uint32_t)(2000 - (DEAD_TIME + 40)) << 16) / (2047 - 137);
 uint16_t TIMER1_MAX_ARR = TIM1_AUTORELOAD; // maximum auto reset register value
 uint16_t duty_cycle_maximum = 2000; // restricted by temperature or low rpm throttle protect
 uint16_t low_rpm_level = 20; // thousand erpm used to set range for throttle resrictions
@@ -459,10 +466,10 @@ uint16_t adjusted_input = 0;
 #define TEMP110_CAL_VALUE ((uint16_t*)((uint32_t)0x1FFFF7C2))
 
 uint16_t smoothedcurrent = 0;
-const uint8_t numReadings = 50; // the readings from the analog input
+#define NUM_CURRENT_READINGS 50 // compile time constant so the divide becomes a multiply
 uint8_t readIndex = 0; // the index of the current reading
 uint32_t total = 0;
-uint16_t readings[50];
+uint16_t readings[NUM_CURRENT_READINGS];
 
 uint8_t bemf_timeout_happened = 0;
 uint8_t changeover_step = 5;
@@ -805,14 +812,14 @@ uint16_t getSmoothedCurrent()
     readings[readIndex] = ADC_raw_current;
     total = total + readings[readIndex];
     readIndex = readIndex + 1;
-    if (readIndex >= numReadings) {
+    if (readIndex >= NUM_CURRENT_READINGS) {
         readIndex = 0;
     }
-    smoothedcurrent = total / numReadings;
+    smoothedcurrent = total / NUM_CURRENT_READINGS;
     return smoothedcurrent;
 }
 
-void getBemfState()
+RAM_FUNC void getBemfState()
 {
     uint8_t current_state = 0;
 #if defined(MCU_F031) || defined(MCU_G031)
@@ -850,7 +857,7 @@ void getBemfState()
     }
 }
 
-void commutate()
+RAM_FUNC void commutate()
 {
     if (forward == 1) {
         step++;
@@ -898,7 +905,7 @@ void commutate()
  * 			This disables the COM_TIMER interrupt.
  * 			Then it enables the comparator to generate its interrupt.
  */
-void PeriodElapsedCallback()
+RAM_FUNC void PeriodElapsedCallback()
 {
     DISABLE_COM_TIMER_INT(); // disable interrupt
     commutate();
@@ -922,7 +929,7 @@ void PeriodElapsedCallback()
  * 			Disables the comparator interrupt.
  * 			Enables the COM_TIMER and sets it to generate an interrupt after the wait time.
  */
-void interruptRoutine()
+RAM_FUNC void interruptRoutine()
 {
 //   if (average_interval > 125) {
 //        if ((INTERVAL_TIMER_COUNT < 125) && (duty_cycle < 600) && (zero_crosses < 500)) { // should be impossible, desync?exit anyway
@@ -1194,10 +1201,16 @@ if (!stepper_sine && armed) {
                 last_duty_cycle = min_startup_duty;
             }
 
+            // straight line from (in_min, out_min) to (2047, 2000) using a
+            // startup computed Q16 slope, avoids calling map() at input rate
             if (eepromBuffer.use_sine_start) {
-                duty_cycle_setpoint = map(input, 137, 2047, minimum_duty_cycle+40, 2000);
+                duty_cycle_setpoint = input >= 2047 ? 2000
+                    : input <= 137 ? minimum_duty_cycle + 40
+                    : minimum_duty_cycle + 40 + (uint16_t)(((uint32_t)(input - 137) * sine_throttle_duty_slope_q16) >> 16);
             } else {
-                duty_cycle_setpoint = map(input, 47, 2047, minimum_duty_cycle, 2000);
+                duty_cycle_setpoint = input >= 2047 ? 2000
+                    : input <= 47 ? minimum_duty_cycle
+                    : minimum_duty_cycle + (uint16_t)(((uint32_t)(input - 47) * throttle_duty_slope_q16) >> 16);
             }
 
             if (!eepromBuffer.rc_car_reverse) {
@@ -1332,7 +1345,7 @@ if (!stepper_sine && armed) {
 #endif
 }
 
-void tenKhzRoutine()
+RAM_FUNC void tenKhzRoutine()
 { // 20khz as of 2.00 to be renamed
     duty_cycle = duty_cycle_setpoint;
     tenkhzcounter++;
@@ -1494,18 +1507,18 @@ void tenKhzRoutine()
         if ((armed && running) && input > 47) {
             if (eepromBuffer.variable_pwm) {
             }
-            adjusted_duty_cycle = ((duty_cycle * tim1_arr) / 2000) + 1;
+            adjusted_duty_cycle = (((uint32_t)duty_cycle * pwm_to_arr_scale_q16) >> 16) + 1;
 
         } else {
 
             if (prop_brake_active) {
-              adjusted_duty_cycle =  tim1_arr - ((prop_brake_duty_cycle * tim1_arr) / 2000);
+              adjusted_duty_cycle =  tim1_arr - (((uint32_t)prop_brake_duty_cycle * pwm_to_arr_scale_q16) >> 16);
             } else {
               if((eepromBuffer.brake_on_stop == 2) && armed){  // require arming for active brake
                 comStep(2);
-                adjusted_duty_cycle = DEAD_TIME + ((eepromBuffer.active_brake_power * tim1_arr) / 2000)* 10;
+                adjusted_duty_cycle = DEAD_TIME + (((uint32_t)eepromBuffer.active_brake_power * pwm_to_arr_scale_q16) >> 16)* 10;
             }else{
-                adjusted_duty_cycle = ((duty_cycle * tim1_arr) / 2000);
+                adjusted_duty_cycle = (((uint32_t)duty_cycle * pwm_to_arr_scale_q16) >> 16);
             }
             }
         }
@@ -1892,6 +1905,13 @@ int main(void)
   startup_max_duty_cycle = startup_max_duty_cycle + 400;
 #endif
 
+    // minimum_duty_cycle is final at this point, precompute the input to duty
+    // cycle slopes so setInput multiplies instead of calling map()
+    throttle_duty_slope_q16 = (((uint32_t)(2000 - minimum_duty_cycle)) << 16) / (2047 - 47);
+    sine_throttle_duty_slope_q16 = (((uint32_t)(2000 - (minimum_duty_cycle + 40))) << 16) / (2047 - 137);
+
+    uint16_t last_tim1_arr = 0; // force scale factor computation on first pass
+
     while (1) {
 e_com_time = ((commutation_intervals[0] + commutation_intervals[1] + commutation_intervals[2] + commutation_intervals[3] + commutation_intervals[4] + commutation_intervals[5]) + 4) >> 1; // COMMUTATION INTERVAL IS 0.5US INCREMENTS 
 
@@ -1931,7 +1951,7 @@ if(zero_crosses < 5){
             tim1_arr = map(commutation_interval, 96, 200, TIMER1_MAX_ARR / 2,
                 TIMER1_MAX_ARR);
         }
-        if (eepromBuffer.variable_pwm == 2) {      // uses automatic range   
+        if (eepromBuffer.variable_pwm == 2) {      // uses automatic range
           if(average_interval < 250 && average_interval > 100){
             tim1_arr = average_interval * (CPU_FREQUENCY_MHZ/9);
           }
@@ -1940,7 +1960,11 @@ if(zero_crosses < 5){
          }
           if((average_interval >= 250) || (average_interval == 0)){
               tim1_arr = 250 * (CPU_FREQUENCY_MHZ/9);
-          } 
+          }
+        }
+        if (tim1_arr != last_tim1_arr) { // keep the 20khz routine scale factor in sync, division
+            last_tim1_arr = tim1_arr;    // happens here at idle priority instead of in the interrupt
+            pwm_to_arr_scale_q16 = ((uint32_t)tim1_arr << 16) / 2000;
         }
         if (signaltimeout > (LOOP_FREQUENCY_HZ >> 1)) { // half second timeout when armed;
             if (armed) {
@@ -2038,8 +2062,12 @@ if(zero_crosses < 5){
         }
 
 #if !defined(MCU_G031) && !defined(NEED_INPUT_READY)
+        // only touch the NVIC when the priority scheme actually changes
+        uint8_t want_input_priority = dshot_telemetry && (commutation_interval > DSHOT_PRIORITY_THRESHOLD);
+        if (want_input_priority != input_priority_is_high) {
+            input_priority_is_high = want_input_priority;
 #ifdef NXP
-	if (dshot_telemetry && (commutation_interval > DSHOT_PRIORITY_THRESHOLD)) {
+	if (want_input_priority) {
 		NVIC_SetPriority(IC_DMA_IRQ_NAME, 0);
 		NVIC_SetPriority(COM_TIMER_IRQ, 1);
 		NVIC_SetPriority(COMP0_IRQ, 1);
@@ -2051,7 +2079,7 @@ if(zero_crosses < 5){
 		NVIC_SetPriority(COMP1_IRQ, 0);
 	}
 #else
-        if (dshot_telemetry && (commutation_interval > DSHOT_PRIORITY_THRESHOLD)) {
+        if (want_input_priority) {
              NVIC_SetPriority(IC_DMA_IRQ_NAME, 0);
              NVIC_SetPriority(COM_TIMER_IRQ, 1);
              NVIC_SetPriority(COMPARATOR_IRQ, 1);
@@ -2061,6 +2089,7 @@ if(zero_crosses < 5){
              NVIC_SetPriority(COMPARATOR_IRQ, 0);
          }
 #endif
+        }
 #endif
         if (send_telemetry) {
 #ifdef USE_SERIAL_TELEMETRY

--- a/e230makefile.mk
+++ b/e230makefile.mk
@@ -29,3 +29,6 @@ CFLAGS_$(MCU) += \
 
 
 SRC_$(MCU) := $(foreach dir,$(SRC_DIR_$(MCU)),$(wildcard $(dir)/*.[cs]))
+
+# LTO inlining at -O3 overflows the 27k flash on this MCU, leave it disabled
+LTO_FLAGS_$(MCU) :=


### PR DESCRIPTION
## Motivation

The F051 (Cortex-M0, 48 MHz, no hardware divider, 1 flash wait-state) runs out of CPU cycles at high eRPM with bidirectional DShot. This PR removes the major cycle sinks in the interrupt hot paths. Most changes benefit every MCU; a few are F051-specific.

## Shared-code changes (all MCUs)

- **Q16 duty-cycle scaling in `tenKhzRoutine`** — `(duty_cycle * tim1_arr) / 2000` ran a ~50–200 cycle soft division (plus the prop-brake/active-brake variants) every 50 µs tick. Now a Q16 reciprocal multiply (`(duty * scale) >> 16`); the scale factor is recomputed in the main loop at idle priority only when `tim1_arr` changes. Verified within 1 timer count of the exact division for all duty values and ARR up to 6012 (max with 8 kHz PWM setting).
- **Throttle→duty slopes in `setInput`** — the two hot `map()` calls (recursive binary interpolation, ~10 nested calls each, runs at DShot frame rate) replaced with startup-computed Q16 straight lines. Note this is *more* linear than before: the old `map()` deviated up to 5/2000 (0.25 % throttle) from a true straight line; servo-input and low-rate `map()` calls are unchanged.
- **Single-pass DShot decode** — `computeDshotDMA` packed pulses into a 16-entry `int` array and re-read it three times to build CRC and value. Now a single packed word with the same CRC/value math (bit-for-bit equivalent, incl. the inverted-CRC bidirectional case). Frees 64 B RAM.
- **Current filter** — `numReadings` was a `const` *variable*, forcing a runtime soft division per 1 kHz sample. Now a `#define` so the compiler emits a multiply sequence. Window stays 50 samples, zero behavior change.
- **NVIC priority writes** — the DShot priority swap wrote 3–4 NVIC registers every main-loop iteration; now only on actual state change (first pass always writes, preserving boot behavior).
- **LTO enabled** (`-flto`) — inlines hot helpers across translation units (`getCompOutputLevel`, `comStep`, `commutate`, LL wrappers); the whole firmware already compiles+links in one gcc invocation so no build restructuring was needed. Opt-outs:
  - `_CAN` builds: gcc 10 LTO trips `-Werror=maybe-uninitialized` false positives in canard/dsdl code, and CAN targets have ample flash anyway.
  - E230: `-O3` LTO inlining overflows its 27 K flash.

## F051-specific changes

- **Hot code runs from RAM (0WS) instead of flash (1WS)** — new `.ramfunc` input section inside `.data` (loaded by the existing startup copy loop), `RAM_FUNC` macro in `targets.h` (empty on other MCUs). In RAM: `ADC1_COMP`/`TIM6_DAC`/`TIM14` IRQ handlers, `interruptRoutine`, `PeriodElapsedCallback`, `commutate`, `comStep`, `tenKhzRoutine`, `getBemfState`, comparator helpers. ~2.9 KB of code; worst-case F051 target keeps 2.1 KB RAM headroom above the 1.5 KB heap/stack reserve.
- **`getCompOutputLevel` inlined** in `comparator.h` — it was an out-of-line cross-TU call inside the comparator-ISR zero-cross filter loop (up to `filter_level` = 12 calls per interrupt, ~15–20 cycles each, now ~4).
- **SysTick interrupt disabled** — its handler is empty; the counter keeps running, only the 1 kHz interrupt (and its ISR entry/exit cost) is gone. Nothing on F051 uses SysTick (`UTILITY_TIMER` is TIM17).

## Latent bugs found by LTO type checking

- `Mcu/g431/Src/stm32g4xx_it.c`: `commutation_interval` declared `volatile uint16_t`, actual definition is `volatile uint32_t` — the early-zero-cross guard read only half the variable.
- `Mcu/a153/Src/DMA.c`: `aTxBuffer` declared `int8_t[18]`, actual is `uint8_t[49]`.
- `Src/dshot.c`: removed unused `extern int zero_crosses` (actual is `volatile uint32_t`).
- `filename[]` needed `__attribute__((used))` to survive LTO into its `.file_name` section.

## Verification

- All 253 targets build cleanly (`make all`, exit 0, no region overflows). Worst-case F051 flash: 92.3 % (ARK_4IN1).
- Disassembly: the 20 kHz handler's per-tick path is division-free (remaining `__aeabi_idiv` calls are in the 1 kHz PID block only); all tagged functions confirmed at `0x2000xxxx` addresses.
- Math equivalence checked exhaustively host-side: Q16 duty scale within 1 timer count of exact; throttle slope within 5/2000 of old `map()` (new version is the exact line).

## What still needs bench testing (why this is a draft)

- **Comparator filter timing**: inlining the comparator read shrinks the zero-cross filter loop's sampling window (~5 µs → ~1.2 µs at `filter_level` 12). Noise immunity on real hardware should be verified at high eRPM / high current; `filter_level` mapping may want retuning.
- RAM-resident ISRs change interrupt latency characteristics (for the better, but worth scoping).
- Normal motor operation: startup, sine mode, bidirectional DShot telemetry, RC-car reverse, brake-on-stop, current limiting.
- Not attempted here (possible follow-ups): dropping `LOOP_FREQUENCY_HZ` back to 10 kHz on F051, PID fixed-point scale change from 10000 to 8192 (would require retuning), extending `RAM_FUNC` to G031/G071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)