### PR TITLE
fix: dronecan timeout when zero input

### DIFF
--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -1249,8 +1249,11 @@ void DroneCAN_update()
         canstats.last_raw_command_us = 0;
         set_input(0);
     }
-    if (ts - last_heartbeat_us > TARGET_PERIOD_US) {
-        // ensure at least 1kHz signal is seen by main code
+    if (canstats.last_raw_command_us != 0 && ts - last_heartbeat_us > TARGET_PERIOD_US) {
+        /*
+          ensure at least 1kHz signal is seen by main code, but only
+          once we have received a RawCommand
+         */
         set_input(last_can_input);
         last_heartbeat_us = ts;
     }

--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -110,6 +110,7 @@ extern uint16_t low_cell_volt_cutoff;
 extern uint32_t desync_happened;
 
 static uint16_t last_can_input;
+static uint64_t last_heartbeat_us;
 static struct {
     uint32_t sum;
     uint32_t count;
@@ -1248,10 +1249,10 @@ void DroneCAN_update()
         canstats.last_raw_command_us = 0;
         set_input(0);
     }
-    if (ts - canstats.last_raw_command_us > TARGET_PERIOD_US) {
+    if (ts - last_heartbeat_us > TARGET_PERIOD_US) {
         // ensure at least 1kHz signal is seen by main code
         set_input(last_can_input);
-        canstats.last_raw_command_us = ts;
+        last_heartbeat_us = ts;
     }
 
     sys_can_enable_IRQ();


### PR DESCRIPTION
## Description of the issue
The DroneCAN version has the unintended behaviour where the ESC never disarms the motor after loss of input, unless a RawCommand 0 is sent. Expected behaiour is that on loss of input, the ESC should disarm after 250ms, but the 1khz last command refresh loop overrides this loop.

## Changes 
This is fixed by adding a `last_heartbeat_us` variable to track timestamp of the last heartbeat message seperately from the last CAN input command. This ensures the 1khz input command refresh loop does not override the timeout watchdog that checks against the timestamp of the last received CAN command.

## Testing
The above firmware was built locally and flashed on a Vimdrones DroneCAN S50 ESC (target: `VIMDRONES_L431_CAN`) and tested compared to the latest v2.20 firmware where the bug was discovered. The fix solved the issue on testing.