### PR TITLE
Add HWCI test rig instrumentation on top of pristine upstream AM32

### DIFF
--- a/.github/workflows/hwci.yml
+++ b/.github/workflows/hwci.yml
@@ -1,0 +1,131 @@
+name: Hardware-in-the-loop CI
+
+# Runs the AM32 firmware on a real ARK 4IN1 ESC mounted on a Tyto Robotics
+# Flight Stand, capturing CPU load / loop times (over SWD) and efficiency /
+# demag (thrust stand), then gates the result against a committed baseline.
+#
+# MANUAL TRIGGER ONLY (workflow_dispatch). The rig needs hands-on preparation
+# before every run - battery connected and charged, prop/torque arm checked,
+# Flight Stand Software up - so a human always starts the run; nothing fires
+# automatically from pushes, PRs, or labels. This also means fork code never
+# reaches the self-hosted bench machine unless a maintainer explicitly enters
+# a PR number in the dispatch form.
+#
+# Requires a self-hosted runner labelled [self-hosted, hwci] that is
+# physically wired to the rig and provisioned per hwci/README.md
+# (ARM toolchain, OpenOCD, ST-Link udev rules, Flight Stand Software + gRPC,
+# a rig config at $HWCI_RIG_CONFIG).
+
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: Test profile to run
+        type: choice
+        default: ci_smoke
+        options: [ci_smoke, efficiency_sweep, demag_step_stress]
+      pr:
+        description: "PR number to test (optional: checks out that PR's head instead of the selected branch)"
+        type: string
+        default: ""
+      battery_cells:
+        description: "Battery cell count on the bench right now (e.g. 6 for 6S); the run refuses to start if pack voltage is too low for this. Leave blank to skip the check."
+        type: string
+        default: "6"
+      save_baseline:
+        description: Save this run's metrics as the new baseline (artifact)
+        type: boolean
+        default: false
+
+concurrency:
+  group: hwci-hardware           # one job at a time owns the physical rig
+  cancel-in-progress: false
+
+jobs:
+  hil:
+    runs-on: [self-hosted, hwci]
+    timeout-minutes: 30
+    env:
+      TARGET: ARK_4IN1_F051
+      PROFILE: ${{ inputs.profile }}
+      BATTERY_CELLS: ${{ inputs.battery_cells }}
+      # Bench-specific config lives on the runner, not in the repo.
+      HWCI_RIG_CONFIG: ${{ vars.HWCI_RIG_CONFIG }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          ref: ${{ inputs.pr != '' && format('refs/pull/{0}/head', inputs.pr) || github.ref }}
+
+      - name: Ensure ARM toolchain
+        shell: bash
+        run: |
+          # make/tools.mk pins ARM_SDK_PREFIX to tools/linux/<xpack>/bin, so a
+          # system arm-none-eabi-gcc on PATH does NOT satisfy the build; install
+          # the pinned SDK whenever the pinned path is missing.
+          if ! ls tools/linux/*/bin/arm-none-eabi-gcc >/dev/null 2>&1; then
+            make arm_sdk_install
+          fi
+
+      - name: Install harness
+        shell: bash
+        working-directory: hwci
+        run: |
+          python3 -m venv .venv
+          . .venv/bin/activate
+          pip install -e '.[plot,flightstand]'
+
+      - name: Run hardware CI
+        id: hil
+        shell: bash
+        working-directory: hwci
+        run: |
+          . .venv/bin/activate
+          RUN_DIR="runs/${GITHUB_SHA::8}-${PROFILE}"
+          echo "run_dir=hwci/$RUN_DIR" >> "$GITHUB_OUTPUT"
+          # Blank input -> no flag at all (hwci ci makes --battery-cells opt-in).
+          BATTERY_ARGS=()
+          if [ -n "$BATTERY_CELLS" ]; then
+            BATTERY_ARGS=(--battery-cells "$BATTERY_CELLS")
+          fi
+          # A missing baseline (first run on a fresh repo) skips the gate with
+          # a warning instead of failing, so save_baseline can bootstrap it.
+          set +e
+          hwci ci \
+            --profile "$PROFILE" \
+            --config "${HWCI_RIG_CONFIG:-$HOME/hwci-rig.yaml}" \
+            --baseline "baselines/${TARGET}.json" \
+            "${BATTERY_ARGS[@]}" \
+            --out "$RUN_DIR"
+          rc=$?
+          set -e
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          exit $rc
+
+      - name: Save baseline (optional)
+        # Runs even when the gate FAILed (rc=1: intentional re-baseline after an
+        # accepted change), but never after an aborted/crashed run (rc >= 2).
+        if: ${{ always() && inputs.save_baseline && contains(fromJSON('["0", "1"]'), steps.hil.outputs.rc) }}
+        shell: bash
+        working-directory: hwci
+        run: |
+          . .venv/bin/activate
+          hwci baseline-save "runs/${GITHUB_SHA::8}-${PROFILE}" \
+            --out "baselines/${TARGET}.json"
+
+      - name: Report to job summary
+        if: always()
+        shell: bash
+        run: |
+          RD="${{ steps.hil.outputs.run_dir }}"
+          if [ -f "$RD/report.md" ]; then cat "$RD/report.md" >> "$GITHUB_STEP_SUMMARY"; fi
+
+      - name: Upload run data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hwci-${{ env.PROFILE }}-${{ github.sha }}
+          path: |
+            ${{ steps.hil.outputs.run_dir }}/
+            hwci/baselines/${{ env.TARGET }}.json
+          retention-days: 90

--- a/Inc/functions.h
+++ b/Inc/functions.h
@@ -11,6 +11,27 @@
 #include "main.h"
 #include "targets.h"
 
+/*
+  get current value of UTILITY_TIMER timer as 16bit microseconds
+ */
+static inline uint16_t get_timer_us16(void)
+{
+#if defined(STMICRO)
+    return UTILITY_TIMER->CNT;
+#elif defined(GIGADEVICES)
+    return TIMER_CNT(UTILITY_TIMER);
+#elif defined(ARTERY)
+    return UTILITY_TIMER->cval;
+#elif defined(NXP)
+    // Return nothing since NXP micro-tick works differently
+    return 0;
+#elif defined(WCH)
+    return UTILITY_TIMER->CNT >> 1;
+#else
+#error unsupported MCU
+#endif
+}
+
 uint32_t getAbsDif(int number1, int number2);
 void delayMicros(uint32_t micros);
 void delayMillis(uint32_t millis);

--- a/Inc/hwci_perf.h
+++ b/Inc/hwci_perf.h
@@ -1,0 +1,207 @@
+/*
+ * hwci_perf.h - Hardware-CI performance instrumentation for AM32
+ *
+ * Optional, compile-gated (HWCI_PERF) instrumentation that maintains a small
+ * struct in RAM with live timing / CPU-load / health counters. A debugger
+ * (ST-Link via OpenOCD, or J-Link) reads this struct non-intrusively over SWD
+ * background memory access while the motor runs.
+ *
+ * WHY a RAM struct instead of SWO/ITM trace:
+ *   The ARK 4IN1 ESC uses the STM32F051 (Cortex-M0 / ARMv6-M). The M0 has no
+ *   DWT cycle counter, no ITM, and no SWO output, so trace-based profiling is
+ *   impossible on ANY probe. Background memory reads of an instrumented struct
+ *   are the portable way to get CPU load and loop times off this core.
+ *
+ * When HWCI_PERF is NOT defined, every macro below expands to a no-op and no
+ * struct or code is emitted - production builds are byte-for-byte unaffected.
+ *
+ * Timestamp source: the free-running 1 MHz utility timer, read through
+ * get_timer_us16() (Inc/functions.h), which handles each vendor family's
+ * register layout. 16-bit (wraps every 65.536 ms); all loop/ISR durations
+ * measured here are far below the wrap period, so 16-bit unsigned subtraction
+ * is exact. Values recorded across a >65 ms blocking event (startup/arming
+ * tunes play with IRQs off inside the control loop) alias - the armed-edge
+ * reset below discards those before a run's measurements start.
+ */
+#ifndef HWCI_PERF_H_
+#define HWCI_PERF_H_
+
+#ifdef HWCI_PERF
+
+#if defined(NXP) || defined(WCH)
+/* NXP has no free-running 1 MHz utility timer (get_timer_us16() returns 0).
+ * On WCH the utility timer doubles as INTERVAL_TIMER, which main.c zeroes at
+ * every zero-cross, so mid-measurement resets would corrupt every reading. */
+#error "HWCI_PERF is not supported on this MCU family (needs a free-running 1 MHz utility timer)"
+#endif
+
+#include <stdint.h>
+
+/* ASCII "HWC1" in little-endian memory order - lets the host locate/validate
+ * the struct either by ELF symbol or by scanning RAM for the magic. */
+#define HWCI_PERF_MAGIC   0x31435748u
+#define HWCI_PERF_VERSION 1u
+
+/* Commands the host may write to hwci_perf.host_cmd (cleared by firmware). */
+#define HWCI_CMD_NONE          0u
+#define HWCI_CMD_RESET_STATS   0xA5u   /* clear the min/max accumulators */
+
+/*
+ * Naturally-aligned layout (NOT packed): Cortex-M0 faults on unaligned word
+ * access, so all 32-bit fields sit on 4-byte boundaries and 16-bit fields on
+ * 2-byte boundaries. The explicit offsets below are the contract the host
+ * decoder (hwci/hwci/perf.py) mirrors. Keep them in sync and bump
+ * HWCI_PERF_VERSION on any layout change.
+ */
+typedef struct hwci_perf_s {
+    uint32_t magic;                    /* off 0  : HWCI_PERF_MAGIC          */
+    uint16_t version;                  /* off 4  : HWCI_PERF_VERSION        */
+    uint16_t size;                     /* off 6  : sizeof(hwci_perf_t)      */
+
+    /* --- loop timing, microseconds (UTILITY_TIMER 1us tick) --- */
+    uint16_t ctrl_exec_us_last;        /* off 8  : last tenKhzRoutine run   */
+    uint16_t ctrl_exec_us_max;         /* off 10 : worst-case run           */
+    uint16_t ctrl_period_us_last;      /* off 12 : last entry-to-entry gap  */
+    uint16_t ctrl_period_us_max;       /* off 14 : worst-case gap (jitter)  */
+    uint16_t ctrl_period_us_min;       /* off 16 : best-case gap            */
+    uint16_t main_loop_us_last;        /* off 18 : last while(1) iteration  */
+    uint16_t main_loop_us_max;         /* off 20 : worst-case iteration     */
+
+    /* --- live state snapshot (mirrors telemetry for self-contained logs) --- */
+    uint16_t input;                    /* off 22 : throttle input 0..2047   */
+    uint16_t duty_cycle;               /* off 24 : applied duty 0..2000     */
+    uint16_t e_rpm;                    /* off 26 : electrical rpm / 100     */
+    uint16_t voltage_cv;               /* off 28 : battery, centivolts      */
+    int16_t  current_ca;               /* off 30 : current, centiamps       */
+    int16_t  temperature_c;            /* off 32 : MCU/FET temp, Celsius    */
+    uint8_t  bemf_timeout_state;       /* off 34 : bemf_timeout_happened    */
+    uint8_t  armed;                    /* off 35 : armed flag               */
+    uint8_t  running;                  /* off 36 : running flag             */
+    uint8_t  _pad0;                    /* off 37 : alignment                */
+    uint16_t _pad1;                    /* off 38 : align next u32 to off 40 */
+
+    /* --- counters ---
+     * loop_iters is monotonic (the host differences it vs wall-clock for the
+     * idle-residual CPU-load estimate). zero_cross_count mirrors main.c's
+     * zero_crosses, which SATURATES at 10000 and resets on desync/stop - it
+     * is a diagnostic value, NOT a monotonic counter. update_count increments
+     * once per snapshot (every HWCI_PERF_SNAPSHOT_DIV main-loop iterations).
+     */
+    uint32_t loop_iters;               /* off 40 : while(1) iterations      */
+    uint32_t zero_cross_count;         /* off 44 : zero_crosses mirror (sat)*/
+    uint32_t commutation_interval;     /* off 48 : raw, 0.5us units         */
+    uint32_t commutation_interval_max; /* off 52 : worst-case (slowest)     */
+    uint32_t update_count;             /* off 56 : ++ each snapshot         */
+    volatile uint32_t host_cmd;        /* off 60 : host writes, fw clears   */
+} hwci_perf_t;                         /* total size: 64 bytes              */
+
+extern volatile hwci_perf_t hwci_perf;
+
+/* Apply a pending host_cmd (e.g. reset accumulators). Defined in hwci_perf.c. */
+void hwci_perf_apply_cmd(void);
+
+/* Clear the sticky min/max accumulators (host command, and automatically on
+ * the armed 0->1 edge to discard aliased values recorded while the arming
+ * tune blocked the control loop). Defined in hwci_perf.c. */
+void hwci_perf_reset_stats(void);
+
+/* 16-bit microsecond timestamp from the free-running utility timer. Macro (not
+ * inline) so it is only evaluated where Inc/functions.h is already included
+ * (the struct definition above stays compilable on a host compiler). */
+#define HWCI_NOW_US() get_timer_us16()
+
+/*
+ * Control-loop (tenKhzRoutine, 20 kHz) instrumentation. ENTER at the very top,
+ * EXIT at the very bottom. ENTER records the period (entry-to-entry); EXIT
+ * records execution time (entry-to-exit). Runs in ISR context - keep it tiny.
+ */
+#define HWCI_PERF_CTRL_ENTER()                                                 \
+    uint16_t _hwci_ctrl_t0 = HWCI_NOW_US();                                    \
+    do {                                                                       \
+        static uint16_t _hwci_last_entry;                                      \
+        static uint8_t  _hwci_ctrl_init;                                       \
+        if (_hwci_ctrl_init) {                                                 \
+            uint16_t _p = (uint16_t)(_hwci_ctrl_t0 - _hwci_last_entry);        \
+            hwci_perf.ctrl_period_us_last = _p;                               \
+            if (_p > hwci_perf.ctrl_period_us_max) hwci_perf.ctrl_period_us_max = _p; \
+            if (_p < hwci_perf.ctrl_period_us_min) hwci_perf.ctrl_period_us_min = _p; \
+        }                                                                      \
+        _hwci_last_entry = _hwci_ctrl_t0;                                      \
+        _hwci_ctrl_init = 1;                                                   \
+    } while (0)
+
+#define HWCI_PERF_CTRL_EXIT()                                                  \
+    do {                                                                       \
+        uint16_t _e = (uint16_t)(HWCI_NOW_US() - _hwci_ctrl_t0);               \
+        hwci_perf.ctrl_exec_us_last = _e;                                      \
+        if (_e > hwci_perf.ctrl_exec_us_max) hwci_perf.ctrl_exec_us_max = _e;  \
+    } while (0)
+
+/*
+ * Background-loop instrumentation. Call once at the top of the main while(1).
+ *
+ * Every iteration: measures iteration time and counts iterations (the host
+ * derives CPU load from the iteration rate vs an idle baseline), so the two
+ * hot signals stay exact.
+ *
+ * Every HWCI_PERF_SNAPSHOT_DIV-th iteration only: snapshots live state and
+ * services host commands. The host samples the struct at <= 200 Hz while the
+ * main loop runs at ~100 kHz, so refreshing the snapshot every iteration would
+ * burn ~10-15% of the core's spare cycles on stores that are overwritten
+ * unread - and, worse, depress the idle loop_iters rate that IS the CPU-load
+ * reference. At DIV=64 the snapshot is never staler than ~1 ms.
+ *
+ * The snapshot references main.c globals, so this macro must be expanded
+ * where those globals are in scope (i.e. in main()). ISR-written globals are
+ * cached into a local before use so the compare and the store can't see two
+ * different values (a torn read would let the sticky max go backwards).
+ */
+#define HWCI_PERF_SNAPSHOT_DIV 64u
+
+#define HWCI_PERF_MAIN_LOOP()                                                  \
+    do {                                                                       \
+        uint16_t _n = HWCI_NOW_US();                                           \
+        static uint16_t _hwci_main_last;                                       \
+        static uint8_t  _hwci_main_init;                                       \
+        static uint8_t  _hwci_prev_armed;                                      \
+        if (_hwci_main_init) {                                                 \
+            uint16_t _d = (uint16_t)(_n - _hwci_main_last);                    \
+            hwci_perf.main_loop_us_last = _d;                                  \
+            if (_d > hwci_perf.main_loop_us_max) hwci_perf.main_loop_us_max = _d; \
+        }                                                                      \
+        _hwci_main_last = _n;                                                  \
+        _hwci_main_init = 1;                                                   \
+        hwci_perf.loop_iters++;                                                \
+        if ((hwci_perf.loop_iters & (HWCI_PERF_SNAPSHOT_DIV - 1u)) == 0u) {    \
+            uint32_t _ci = commutation_interval;                               \
+            uint8_t _armed = (uint8_t)armed;                                   \
+            hwci_perf.input = input;                                           \
+            hwci_perf.duty_cycle = duty_cycle;                                 \
+            hwci_perf.e_rpm = e_rpm;                                           \
+            hwci_perf.voltage_cv = battery_voltage;                            \
+            hwci_perf.current_ca = actual_current;                             \
+            hwci_perf.temperature_c = degrees_celsius;                         \
+            hwci_perf.bemf_timeout_state = (uint8_t)bemf_timeout_happened;     \
+            hwci_perf.armed = _armed;                                          \
+            hwci_perf.running = (uint8_t)running;                              \
+            hwci_perf.zero_cross_count = zero_crosses;                         \
+            hwci_perf.commutation_interval = _ci;                              \
+            if (_ci > hwci_perf.commutation_interval_max)                      \
+                hwci_perf.commutation_interval_max = _ci;                      \
+            if (_armed && !_hwci_prev_armed)                                   \
+                hwci_perf_reset_stats(); /* drop aliased arming-tune maxima */ \
+            _hwci_prev_armed = _armed;                                         \
+            hwci_perf.update_count++;                                          \
+            if (hwci_perf.host_cmd != HWCI_CMD_NONE) hwci_perf_apply_cmd();    \
+        }                                                                      \
+    } while (0)
+
+#else /* !HWCI_PERF - all hooks vanish, no struct, no code */
+
+#define HWCI_PERF_CTRL_ENTER() do {} while (0)
+#define HWCI_PERF_CTRL_EXIT()  do {} while (0)
+#define HWCI_PERF_MAIN_LOOP()  do {} while (0)
+
+#endif /* HWCI_PERF */
+
+#endif /* HWCI_PERF_H_ */

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,14 @@ CFLAGS_BASE += -Wall -Wundef -Wextra -Werror -Wno-unused-parameter -Wno-stringop
 
 CFLAGS_COMMON := $(CFLAGS_BASE)
 
+# Hardware-CI performance instrumentation (opt-in, off by default).
+# Build with `make <TARGET> HWCI_PERF=1` to emit the hwci_perf RAM struct that
+# the hardware-CI harness (see hwci/) reads over SWD. Production/release builds
+# leave this unset and are completely unaffected.
+ifeq ($(HWCI_PERF),1)
+CFLAGS_COMMON += -DHWCI_PERF
+endif
+
 # Linker options
 LDFLAGS_COMMON := -specs=nano.specs $(LIBS) -Wl,--gc-sections -Wl,--print-memory-usage
 

--- a/Src/functions.c
+++ b/Src/functions.c
@@ -48,25 +48,8 @@ uint32_t getAbsDif(int number1, int number2)
     return (uint32_t)result;
 }
 
-/*
-  get current value of UTILITY_TIMER timer as 16bit microseconds
- */
-static inline uint16_t get_timer_us16(void) {
-#if defined(STMICRO)
-    return UTILITY_TIMER->CNT;
-#elif defined(GIGADEVICES)
-    return TIMER_CNT(UTILITY_TIMER);
-#elif defined(ARTERY)
-    return UTILITY_TIMER->cval;
-#elif defined(NXP)
-    //Return nothing since NXP micro-tick works differently
-    return 0;
-#elif defined(WCH)
-    return UTILITY_TIMER->CNT>>1;
-#else
-#error unsupported MCU
-#endif
-}
+/* get_timer_us16() lives in Inc/functions.h so other units (e.g. the HWCI_PERF
+ * instrumentation) share the same per-family utility-timer access. */
 
 /*
   delay by microseconds, max 65535

--- a/Src/hwci_perf.c
+++ b/Src/hwci_perf.c
@@ -1,0 +1,62 @@
+/*
+ * hwci_perf.c - Hardware-CI performance instrumentation for AM32
+ *
+ * See Inc/hwci_perf.h for the rationale and the struct-layout contract.
+ *
+ * The whole translation unit is empty unless HWCI_PERF is defined, so it is
+ * safe to leave in the common source list (the Makefile globs the Src
+ * directory); default builds emit nothing from it.
+ */
+#include "hwci_perf.h"
+
+#ifdef HWCI_PERF
+
+/*
+ * The single instrumentation struct. Kept volatile so the compiler never
+ * caches fields (the debugger reads them asynchronously over SWD) and never
+ * elides the storage. The host finds it by the ELF symbol "hwci_perf".
+ *
+ * Min/extreme accumulators are seeded so the first real sample replaces them.
+ */
+volatile hwci_perf_t hwci_perf = {
+    .magic = HWCI_PERF_MAGIC,
+    .version = HWCI_PERF_VERSION,
+    .size = (uint16_t)sizeof(hwci_perf_t),
+    .ctrl_period_us_min = 0xFFFFu,
+    .host_cmd = HWCI_CMD_NONE,
+};
+
+/*
+ * Clear the sticky min/max accumulators so worst-case timing can be measured
+ * for a single test run without power-cycling the ESC. Called for the host
+ * HWCI_CMD_RESET_STATS command, and automatically on the armed 0->1 edge
+ * (the arming tune blocks the control loop for ~300 ms with IRQs off, so the
+ * 16-bit timestamps recorded around it alias to garbage that must not leak
+ * into a run's maxima regardless of when the host issues its reset).
+ */
+void hwci_perf_reset_stats(void)
+{
+    hwci_perf.ctrl_exec_us_max = 0;
+    hwci_perf.ctrl_period_us_max = 0;
+    hwci_perf.ctrl_period_us_min = 0xFFFFu;
+    hwci_perf.main_loop_us_max = 0;
+    hwci_perf.commutation_interval_max = 0;
+}
+
+/*
+ * Service a host command. Called from the main loop (low priority) when
+ * host_cmd is non-zero. Always clears host_cmd so the command fires once.
+ */
+void hwci_perf_apply_cmd(void)
+{
+    switch (hwci_perf.host_cmd) {
+    case HWCI_CMD_RESET_STATS:
+        hwci_perf_reset_stats();
+        break;
+    default:
+        break;
+    }
+    hwci_perf.host_cmd = HWCI_CMD_NONE;
+}
+
+#endif /* HWCI_PERF */

--- a/Src/main.c
+++ b/Src/main.c
@@ -227,6 +227,7 @@ an settings option)
 #include "phaseouts.h"
 #include "serial_telemetry.h"
 #include "kiss_telemetry.h"
+#include "hwci_perf.h"
 #include "signal.h"
 #include "sounds.h"
 #include "targets.h"
@@ -1334,6 +1335,7 @@ if (!stepper_sine && armed) {
 
 void tenKhzRoutine()
 { // 20khz as of 2.00 to be renamed
+    HWCI_PERF_CTRL_ENTER();
     duty_cycle = duty_cycle_setpoint;
     tenkhzcounter++;
     ledcounter++;
@@ -1527,6 +1529,7 @@ void tenKhzRoutine()
     signaltimeout++;
 
 #endif
+    HWCI_PERF_CTRL_EXIT();
 }
 
 void processDshot()
@@ -1893,6 +1896,7 @@ int main(void)
 #endif
 
     while (1) {
+        HWCI_PERF_MAIN_LOOP();
 e_com_time = ((commutation_intervals[0] + commutation_intervals[1] + commutation_intervals[2] + commutation_intervals[3] + commutation_intervals[4] + commutation_intervals[5]) + 4) >> 1; // COMMUTATION INTERVAL IS 0.5US INCREMENTS 
 
 #if defined(FIXED_DUTY_MODE) || defined(FIXED_SPEED_MODE)

--- a/hwci/.gitignore
+++ b/hwci/.gitignore
@@ -1,0 +1,14 @@
+# Python
+.venv/
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+
+# Run outputs (data is captured per-run; commit baselines/ only)
+runs/
+rig.yaml
+hwci/flightstand/_generated/
+
+# pip build artifacts
+build/

--- a/hwci/README.md
+++ b/hwci/README.md
@@ -1,0 +1,266 @@
+# AM32 Hardware-CI Harness (ARK 4IN1 ESC)
+
+A hardware-in-the-loop test harness for improving AM32 on the **ARK 4IN1 ESC**.
+It builds and flashes firmware, drives a motor through a **Tyto Robotics Flight
+Stand 50**, and at the same time reads firmware **CPU-load / loop-time**
+instrumentation off the MCU over **SWD**, then turns it all into metrics, a
+baseline, and a pass/fail report you can gate pull requests on.
+
+```
+                 ┌───────────────────────── Ubuntu 24.04 host ─────────────────────────┐
+                 │                                                                       │
+  ST-Link  ◄─SWD─┤  OpenOCD ──background RAM reads──►  hwci_perf struct (loop µs, iters) │
+                 │                                                                       │
+  USB-serial ◄───┤  KISS telemetry reader  ◄────────  ESC telem wire (eRPM, V, A, °C)    │
+                 │                                                                       │
+  Flight Stand◄──┤  gRPC client  ──throttle──►  ESC signal   ──measures──► thrust/torque/│
+   (gRPC)        │                                              RPM/V/A → efficiency g/W │
+                 │                                                                       │
+                 │  runner → metrics → baseline compare → report.md + plots + exit code  │
+                 └───────────────────────────────────────────────────────────────────────┘
+            ARK 4IN1 ESC (4× STM32F051 / Cortex-M0) ── motor ── prop ── Flight Stand 50
+```
+
+## Why it's built this way (read this first)
+
+The ARK 4IN1 runs **four independent STM32F051 MCUs** (one per channel), each a
+**Cortex-M0 (ARMv6-M)**. The M0 has **no DWT cycle counter, no ITM, and no SWO**
+— so the usual "profile over SWO/ITM trace" approach is **impossible on any
+debug probe**, ST-Link or J-Link alike.
+
+So CPU load and loop times are recovered a different way:
+
+1. The firmware keeps a tiny instrumentation struct (`hwci_perf`) in RAM,
+   updated from the 20 kHz control loop and the main loop using the existing
+   1 µs free-running timer (`UTILITY_TIMER`/TIM17).
+2. The debugger reads that struct **without halting the core** via SWD
+   background memory access (works on the M0; it's the same mechanism as IDE
+   "live watch"). Both ST-Link (OpenOCD) and J-Link support it; **ST-Link +
+   OpenOCD is the default** because you already use it to flash the bootloader
+   and the OpenOCD config already ships in the repo.
+3. **CPU load** uses the idle-residual method: the firmware exposes a
+   free-running `loop_iters` counter whose rate (iters/s) is highest when the
+   core is least loaded, so `cpu_load = 1 − rate/idle_rate`.
+
+Efficiency and demag come from the thrust stand + ESC telemetry, correlated on
+the host. Demag/desync is detected from RPM/thrust collapse at high throttle,
+ESC-eRPM vs stand-RPM divergence, commutation-interval spikes, and the firmware
+bemf-timeout flag.
+
+## What it measures
+
+| Channel | Source | Metrics |
+|---|---|---|
+| CPU load | `hwci_perf.loop_iters` via SWD | % load vs idle baseline, per operating point |
+| Loop times | `hwci_perf` ctrl/main timers via SWD | worst-case 20 kHz exec µs, period jitter, main-loop µs |
+| Efficiency | Flight Stand thrust + V·A | thrust (gf), electrical power (W), **g/W** per throttle |
+| Demag | stand RPM + KISS eRPM + perf | desync events, eRPM/RPM mismatch, commutation spikes |
+| Health | KISS telemetry | voltage, current, temperature, consumption |
+
+## Firmware instrumentation (`HWCI_PERF`)
+
+The instrumentation is **opt-in and zero-cost when off**. Build it with:
+
+```
+make ARK_4IN1_F051 HWCI_PERF=1
+```
+
+* When `HWCI_PERF` is **unset** (all production/release builds), every hook
+  expands to nothing — the binary is byte-for-byte identical.
+* When **set**, it adds ~**530 B flash** and **72 B RAM** on the F051 and emits
+  the `hwci_perf` symbol the host locates via the ELF (address + DWARF layout,
+  so host and firmware can never silently disagree — there's a test for it).
+
+Files: `Inc/hwci_perf.h`, `Src/hwci_perf.c`, three hooks in `Src/main.c`
+(`tenKhzRoutine` enter/exit, `while(1)` top), one `Makefile` flag.
+
+## Hardware setup
+
+### Debug (one channel at a time)
+
+The ARK 4IN1 exposes all four SWD pairs on a single 10-pin debug header:
+
+| pin | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 |
+|----|---|---|---|---|---|---|---|---|---|----|
+| sig | 3V3 | SWDIO1 | SWCLK1 | SWDIO2 | SWCLK2 | SWDIO3 | SWCLK3 | SWDIO4 | SWCLK4 | GND |
+
+Wire the ST-Link to the SWDIO/SWCLK pair of the channel whose motor is on the
+stand (channel 1 by convention). **Do not** connect the ST-Link 3V3 when the ESC
+is powered from a battery/supply — share GND only. All four dies run identical
+firmware, so one channel's loop-time/CPU data is representative; efficiency is
+per-motor.
+
+### Signal, telemetry, power
+
+* **Throttle**: Flight Stand ESC output → channel-1 signal pin (PWM or DShot).
+  If your stand can't emit the protocol you want, use an external DShot
+  generator (`throttle_backend: external`).
+* **ESC telemetry**: channel-1 telemetry pad → USB-serial adapter (115200 8N1)
+  → host. The ARK target already has `USE_SERIAL_TELEMETRY`.
+* **Power**: bench supply or battery within the ARK 4IN1's 3–8S range; common
+  ground between supply, ESC, stand, and host.
+* **Safety**: set conservative cutoffs in the profile `safety:` block (current,
+  thrust, RPM, voltage, temperature) — the **runner enforces them host-side on
+  every sample** (stand reading and ESC telemetry alike) and aborts the run on
+  breach. Also configure the Flight Stand Software's own UI cutoffs as an
+  independent second layer (the vendor set-limit RPC is not mapped yet). Secure
+  the motor/prop; use a prop guard; keep clear during demag-stress runs.
+* **Battery**: pass `--battery-cells N` to `hwci run`/`hwci ci` (e.g. `6` for a
+  6S pack) to refuse to *start* a test when the pack is already at or below
+  `N * --min-cell-voltage` (default 3.3 V/cell, matching AM32 firmware's own
+  low-voltage-cutoff default). This is a pre-flight gate checked once before
+  the throttle is armed — separate from, and in addition to, the per-sample
+  `safety:` limits above. It reads the stand's voltage channel, or the perf
+  struct on a stand-less bench. Opt-in and hardware-only (has no effect under
+  `--sim`, since the simulator's pack has no real cell count).
+
+## Software setup (Ubuntu 24.04)
+
+```bash
+cd hwci
+./scripts/setup_ubuntu.sh        # apt deps, ARM toolchain, OpenOCD, udev, venv
+```
+
+Then, manually (vendor bits the script can't automate):
+
+1. The **Tyto Flight Stand Software runs on Windows only** (no Linux build as
+   of v2.4.x). Install it on a Windows PC on the bench network, plug the
+   stand's USB into that PC, and launch the software with the `--remote`
+   flag so the gRPC API accepts non-local connections. Point `stand_host`
+   in `rig.yaml` at that PC. (The GUI is also where you configure the
+   vendor-side safety cutoffs. Load cells don't need a manual tare before
+   each run: `hwci run`/`hwci ci` tare automatically as the last pre-flight
+   step — with the ESC signal already up at zero throttle, because AM32
+   beeps the motor whenever it has no input signal and those beeps shake
+   the cells mid-tare. `--no-tare` skips it.)
+2. Clone Tyto's API repo — it ships **pre-compiled Python stubs**, no protoc
+   run needed — and make it importable in the harness venv:
+   ```bash
+   git clone https://gitlab.com/TytoRobotics/flightstand-api ~/flightstand-api
+   .venv/bin/pip install grpcio protobuf
+   echo ~/flightstand-api/languages/python > \
+       .venv/lib/python3*/site-packages/flightstand_api.pth
+   ```
+   `hwci/hwci/flightstand/grpc_client.py` is mapped against
+   `flight_stand_api_v1.proto` (Flight Stand Software 2.4.x); the
+   proto-aware calls stay isolated in `_StubAdapter` if Tyto's API moves.
+3. `cp config/rig.example.yaml rig.yaml` and edit ports/host/signal map/motor.
+4. Edit `/etc/udev/rules.d/99-hwci.rules` with your USB-serial serial numbers so
+   `/dev/esc-telem` (and `/dev/esc-throttle`) appear.
+5. ESC telemetry only streams if the AM32 EEPROM setting
+   `telemetry_on_interval` is enabled (AM32 configurator: "30ms telemetry").
+   With it off, the KISS channel is silent even when wired correctly. On a
+   bench without the telemetry wire, set `telem_backend: none` — the perf
+   struct still reports eRPM/voltage/current/temperature over SWD.
+
+Verify the harness with **no hardware** at any time:
+
+```bash
+python -m hwci selftest          # runs ci_smoke in the built-in simulator
+python -m pytest                 # 75 offline tests
+```
+
+## Usage
+
+```bash
+hwci profiles                                   # list test profiles
+hwci build --config rig.yaml                    # make ARK_4IN1_F051 HWCI_PERF=1
+hwci flash --config rig.yaml                    # OpenOCD program @ 0x08001000
+hwci run  --profile efficiency_sweep --config rig.yaml --battery-cells 6 --out runs/r1
+hwci analyze runs/r1                            # -> metrics.json
+hwci report runs/r1 --baseline baselines/ARK_4IN1_F051.json
+hwci ci   --profile ci_smoke --config rig.yaml --battery-cells 6 \
+          --baseline baselines/ARK_4IN1_F051.json --out runs/ci   # full gate
+```
+
+`--battery-cells` is optional but recommended on hardware runs: it refuses to
+start the test at all if the pack is already too low (see Safety, below),
+instead of arming and collecting a run's worth of data from a sagging supply.
+
+`hwci ci` builds (HWCI_PERF=1) → flashes → runs the profile → computes metrics →
+compares to the baseline → writes `report.md` + `summary.png`, and **exits
+non-zero on regression** so CI fails the build.
+
+Built-in profiles: `ci_smoke` (fast gate), `efficiency_sweep` (10–100 %
+staircase, the primary baseline), `demag_step_stress` (aggressive steps).
+
+## Capturing the first baseline
+
+Once wired and configured:
+
+```bash
+cd hwci
+# 1. Sanity-check the full path on hardware with the short profile:
+hwci ci --profile ci_smoke --config rig.yaml --battery-cells 6 --out runs/smoke
+# 2. Capture the performance baseline:
+hwci ci --profile efficiency_sweep --config rig.yaml --battery-cells 6 --out runs/baseline
+hwci baseline-save runs/baseline --out baselines/ARK_4IN1_F051.json
+git add baselines/ARK_4IN1_F051.json && git commit -m "hwci: ARK 4IN1 baseline"
+```
+
+A `--baseline` pointing at a file that doesn't exist yet prints a warning and
+skips the gate (instead of failing), so the very first CI run — including a
+`save_baseline` dispatch — can bootstrap the baseline itself.
+
+`runs/baseline/report.md` is your benchmark: thrust & efficiency per throttle,
+worst-case 20 kHz loop time, CPU load, and zero demag events on the swept ramp.
+Every later change is graded against it.
+
+The regression gate **fails closed**: a metric that is missing/NaN (dead SWD or
+telemetry channel, misconfigured backend) fails its check, and per-channel
+coverage checks (`perf_coverage`, `stand_coverage`, `telem_coverage`) name the
+dead channel explicitly. A green run therefore proves the instrumentation was
+alive, not just that nothing compared worse.
+
+## CI integration
+
+`.github/workflows/hwci.yml` runs on a self-hosted runner labelled
+`[self-hosted, hwci]` wired to the rig. It is **manual-dispatch only**: the rig
+needs hands-on preparation (battery connected/charged, prop and torque arm
+checked, Flight Stand Software running), so a human always starts the run —
+nothing triggers from pushes, PRs, or labels, and fork code never reaches the
+bench unless a maintainer explicitly enters a PR number in the dispatch form.
+Pick a profile (and optionally a PR number and `save_baseline`) in the form;
+the workflow serializes hardware access with a concurrency group, posts
+`report.md` to the job summary, uploads the run data, and fails the job on
+regression (exit 1) or abort (exit 2). Set the repo/runner variable
+`HWCI_RIG_CONFIG` to the path of `rig.yaml` on the bench.
+
+## Repo layout
+
+```
+Inc/hwci_perf.h, Src/hwci_perf.c   firmware instrumentation (HWCI_PERF)
+hwci/hwci/perf.py, elf.py          perf struct decode + ELF/DWARF symbol lookup
+hwci/hwci/debugger/                OpenOCD (ST-Link) + Mock backends
+hwci/hwci/flightstand/             gRPC client + simulator + base interface
+hwci/hwci/esc_telem/kiss.py        KISS telemetry parser
+hwci/hwci/throttle/                flight-stand / external / base throttle sources
+hwci/hwci/sim.py                   offline rig simulator (all 3 channels)
+hwci/hwci/runner.py metrics.py baseline.py report.py config.py cli.py
+hwci/hwci/profiles/*.yaml          test profiles
+hwci/tests/                        75 offline tests (sim, DWARF layout, fail-closed gating)
+```
+
+## Honest limitations
+
+* The **gRPC client** is mapped against Tyto's published
+  `flight_stand_api_v1.proto` (Flight Stand Software 2.4.x): inputs are
+  discovered by `InputType` (FORCE_FZ=11 etc.), all signals are read in one
+  `ListSamples` round trip, and throttle goes out via `UpdateOutput` on the
+  ESC output's `output_target`. Tyto guarantees no cross-version API
+  compatibility, so re-check `_StubAdapter` after a Flight Stand Software
+  update. The API reports SI units (Newtons, rad/s) — `thrust_is_grams:
+  false`, `rpm_is_rad_per_s: true` in the signal map.
+* The **AM32 bootloader only jumps to the app when the throttle signal line
+  idles low at boot**. An inactive stand output can leave the line high and
+  park the ESC in the bootloader after every flash or power-cycle (observed
+  on the ARK 4IN1 bench). Live-source bring-up detects this via the perf
+  magic, commands zero throttle, resets the MCU, and waits for the app —
+  see `_ensure_app_alive` in `hwci/runner.py`.
+* `HWCI_PERF` is validated for the STM32F0 (ARK 4IN1). The timestamp macro uses
+  the shared `get_timer_us16()` helper, so STM32/GigaDevice/Artery targets
+  compile with `HWCI_PERF=1`; NXP and WCH are `#error`-gated (no usable
+  free-running 1 µs timer). With the flag unset, every target is untouched.
+* CPU load is a statistical idle-residual figure, not a per-function profile
+  (the M0 can't do PC sampling); it's stable and comparable run-to-run, which is
+  what regression gating needs.

--- a/hwci/baselines/ARK_4IN1_F051.json
+++ b/hwci/baselines/ARK_4IN1_F051.json
@@ -1,0 +1,202 @@
+{
+  "format_version": 1,
+  "meta": {
+    "aborted": null,
+    "git_sha": "3f8fad7",
+    "mode": "hw",
+    "motor": "JS Technology 2306 1800KV",
+    "n_samples": 3700,
+    "perf_read_errors": 0,
+    "pole_pairs": 7,
+    "profile": "noprop_baseline",
+    "profile_def": {
+      "arm_settle_s": 3.0,
+      "demag_commutation_spike": 3.0,
+      "demag_rpm_drop_fraction": 0.25,
+      "description": "No-prop performance baseline: steady staircase 10% to 50% throttle. Without a prop there is no meaningful thrust/efficiency, but loop timing, CPU load, commutation health, eRPM-vs-stand-RPM agreement, and no-load current per operating point are all stable regression signals. Capped at 50% (a free 1800KV bell on 6S already turns ~22k RPM there); raise only with a load. ~40 s.\n",
+      "name": "noprop_baseline",
+      "pole_pairs": 7,
+      "safety": {
+        "max_current_a": 10.0,
+        "max_motor_temp_c": 80.0,
+        "max_rpm": 28000,
+        "max_thrust_n": 3.0,
+        "max_voltage_v": null
+      },
+      "sample_rate_hz": 100.0,
+      "segments": [
+        {
+          "duration_s": 2.0,
+          "label": "idle",
+          "ramp": false,
+          "steady": false,
+          "throttle": 0.0
+        },
+        {
+          "duration_s": 6.0,
+          "label": "t10",
+          "ramp": true,
+          "steady": true,
+          "throttle": 0.1
+        },
+        {
+          "duration_s": 6.0,
+          "label": "t20",
+          "ramp": false,
+          "steady": true,
+          "throttle": 0.2
+        },
+        {
+          "duration_s": 6.0,
+          "label": "t30",
+          "ramp": false,
+          "steady": true,
+          "throttle": 0.3
+        },
+        {
+          "duration_s": 6.0,
+          "label": "t40",
+          "ramp": false,
+          "steady": true,
+          "throttle": 0.4
+        },
+        {
+          "duration_s": 6.0,
+          "label": "t50",
+          "ramp": false,
+          "steady": true,
+          "throttle": 0.5
+        },
+        {
+          "duration_s": 3.0,
+          "label": "rampdn",
+          "ramp": true,
+          "steady": false,
+          "throttle": 0.0
+        },
+        {
+          "duration_s": 2.0,
+          "label": "stop",
+          "ramp": false,
+          "steady": false,
+          "throttle": 0.0
+        }
+      ],
+      "steady_tail_fraction": 0.5
+    },
+    "prop": "none",
+    "sample_rate_hz": 100.0,
+    "target": "ARK_4IN1_F051",
+    "timestamp": "2026-07-02T14:03:21",
+    "wall_time_s": 37.0
+  },
+  "metrics": {
+    "demag": {
+      "bemf_timeout_samples": 0,
+      "comm_spike_samples": 0,
+      "esc_rpm_mismatch_samples": 0,
+      "event_count": 0,
+      "events": [],
+      "median_commutation_interval": 162.0,
+      "rpm_drop_samples": 0
+    },
+    "steady_points": [
+      {
+        "cpu_load_pct": 39.7,
+        "ctrl_exec_us_max": 76,
+        "current_a": 0.069,
+        "eff_gf_per_w": 2.191,
+        "elec_power_w": 1.69,
+        "fet_temp_c": 25.4,
+        "main_loop_us_max": 138,
+        "motor_temp_c": 24.14,
+        "rpm": 3919.7,
+        "segment": "t10",
+        "throttle": 0.1,
+        "thrust_gf": 2.03,
+        "voltage_v": 24.441
+      },
+      {
+        "cpu_load_pct": 54.4,
+        "ctrl_exec_us_max": 70,
+        "current_a": 0.331,
+        "eff_gf_per_w": 0.438,
+        "elec_power_w": 8.07,
+        "fet_temp_c": 25.77,
+        "main_loop_us_max": 141,
+        "motor_temp_c": 24.22,
+        "rpm": 9357.8,
+        "segment": "t20",
+        "throttle": 0.2,
+        "thrust_gf": 3.6,
+        "voltage_v": 24.414
+      },
+      {
+        "cpu_load_pct": 46.9,
+        "ctrl_exec_us_max": 67,
+        "current_a": 0.542,
+        "eff_gf_per_w": 0.246,
+        "elec_power_w": 13.22,
+        "fet_temp_c": 26.42,
+        "main_loop_us_max": 141,
+        "motor_temp_c": 24.29,
+        "rpm": 13414.6,
+        "segment": "t30",
+        "throttle": 0.3,
+        "thrust_gf": 3.11,
+        "voltage_v": 24.386
+      },
+      {
+        "cpu_load_pct": 49.7,
+        "ctrl_exec_us_max": 65,
+        "current_a": 0.792,
+        "eff_gf_per_w": 0.285,
+        "elec_power_w": 19.29,
+        "fet_temp_c": 27.1,
+        "main_loop_us_max": 146,
+        "motor_temp_c": 24.39,
+        "rpm": 17603.1,
+        "segment": "t40",
+        "throttle": 0.4,
+        "thrust_gf": 2.46,
+        "voltage_v": 24.355
+      },
+      {
+        "cpu_load_pct": 53.2,
+        "ctrl_exec_us_max": 57,
+        "current_a": 0.975,
+        "eff_gf_per_w": 0.124,
+        "elec_power_w": 23.71,
+        "fet_temp_c": 27.72,
+        "main_loop_us_max": 136,
+        "motor_temp_c": 24.53,
+        "rpm": 21744.2,
+        "segment": "t50",
+        "throttle": 0.5,
+        "thrust_gf": 2.93,
+        "voltage_v": 24.322
+      }
+    ],
+    "summary": {
+      "bemf_timeout_samples": 0,
+      "best_ctrl_period_us": 8,
+      "demag_events": 0,
+      "idle_loop_rate_hz": 58527.9,
+      "max_cpu_load_pct": 56.8,
+      "max_current_a": 3.22,
+      "max_fet_temp_c": 28.17,
+      "max_motor_temp_c": 24.69,
+      "max_thrust_gf": 34,
+      "n_samples": 3700,
+      "peak_efficiency_gf_per_w": 2.191,
+      "perf_sample_count": 3700,
+      "stand_sample_count": 3700,
+      "telem_sample_count": 0,
+      "worst_ctrl_exec_us": 597,
+      "worst_ctrl_exec_us_steady": 76,
+      "worst_ctrl_period_us": 599,
+      "worst_main_loop_us": 635,
+      "worst_main_loop_us_steady": 146
+    }
+  }
+}

--- a/hwci/baselines/ARK_4IN1_F051_HQ5136.json
+++ b/hwci/baselines/ARK_4IN1_F051_HQ5136.json
@@ -1,0 +1,307 @@
+{
+  "format_version": 1,
+  "meta": {
+    "aborted": null,
+    "battery_cells": 6,
+    "git_sha": "126590d",
+    "mode": "hw",
+    "motor": "JS Technology 2306 1800KV",
+    "n_samples": 6600,
+    "perf_read_errors": 0,
+    "pole_pairs": 7,
+    "profile": "efficiency_sweep",
+    "profile_def": {
+      "arm_settle_s": 2.0,
+      "demag_commutation_spike": 3.0,
+      "demag_rpm_drop_fraction": 0.25,
+      "description": "Steady-state staircase from 10% to 100% throttle. Each step dwells long enough to settle, and the tail of each is used to compute thrust, electrical power and efficiency (g/W) plus loop time / CPU load at that operating point. This is the primary efficiency + performance baseline.\nHold time is 6s. It was temporarily 10s while the ARK 4IN1 bench had severe thrust-channel noise (sample CV up to 66%) that turned out to be prop-wake impingement on the stand's mounting plate - the 5\" disc sat entirely inside the plate footprint blowing INTO it - not vibration to be averaged away. With the prop reversed to exhaust into free air (thrust CV now 5.5-8.8%), re-analysis of four 10s-hold captures truncated to 6s showed a 3s tail changes gated points (>= 20W) by under +/-2% and leaves run-to-run repeatability statistically unchanged (worst gated-point spread 9.8% vs 9.1%), so the extra 4s/point (~40s of motor+battery per sweep) bought nothing. See Thresholds.efficiency_drop_pct in hwci/baseline.py for the matching tolerance history.\n",
+      "name": "efficiency_sweep",
+      "pole_pairs": 7,
+      "safety": {
+        "max_current_a": 40.0,
+        "max_motor_temp_c": null,
+        "max_rpm": 32000,
+        "max_thrust_n": 16.0,
+        "max_voltage_v": null
+      },
+      "sample_rate_hz": 100.0,
+      "segments": [
+        {
+          "duration_s": 2.0,
+          "label": "idle",
+          "ramp": false,
+          "steady": false,
+          "throttle": 0.0
+        },
+        {
+          "duration_s": 6.0,
+          "label": "t10",
+          "ramp": true,
+          "steady": true,
+          "throttle": 0.1
+        },
+        {
+          "duration_s": 6.0,
+          "label": "t20",
+          "ramp": false,
+          "steady": true,
+          "throttle": 0.2
+        },
+        {
+          "duration_s": 6.0,
+          "label": "t30",
+          "ramp": false,
+          "steady": true,
+          "throttle": 0.3
+        },
+        {
+          "duration_s": 6.0,
+          "label": "t40",
+          "ramp": false,
+          "steady": true,
+          "throttle": 0.4
+        },
+        {
+          "duration_s": 6.0,
+          "label": "t50",
+          "ramp": false,
+          "steady": true,
+          "throttle": 0.5
+        },
+        {
+          "duration_s": 6.0,
+          "label": "t60",
+          "ramp": false,
+          "steady": true,
+          "throttle": 0.6
+        },
+        {
+          "duration_s": 6.0,
+          "label": "t70",
+          "ramp": false,
+          "steady": true,
+          "throttle": 0.7
+        },
+        {
+          "duration_s": 6.0,
+          "label": "t80",
+          "ramp": false,
+          "steady": true,
+          "throttle": 0.8
+        },
+        {
+          "duration_s": 6.0,
+          "label": "t90",
+          "ramp": false,
+          "steady": true,
+          "throttle": 0.9
+        },
+        {
+          "duration_s": 6.0,
+          "label": "t100",
+          "ramp": false,
+          "steady": true,
+          "throttle": 1.0
+        },
+        {
+          "duration_s": 4.0,
+          "label": "rampdn",
+          "ramp": true,
+          "steady": false,
+          "throttle": 0.0
+        }
+      ],
+      "steady_tail_fraction": 0.5
+    },
+    "prop": "HQProp 5136 R36-GR-PC",
+    "sample_rate_hz": 100.0,
+    "tared": true,
+    "target": "ARK_4IN1_F051",
+    "timestamp": "2026-07-02T17:16:13",
+    "wall_time_s": 66.005
+  },
+  "metrics": {
+    "demag": {
+      "bemf_timeout_samples": 0,
+      "comm_spike_samples": 0,
+      "esc_rpm_mismatch_samples": 0,
+      "event_count": 0,
+      "events": [],
+      "median_commutation_interval": 130.0,
+      "rpm_drop_samples": 0
+    },
+    "steady_points": [
+      {
+        "cpu_load_pct": 39.0,
+        "ctrl_exec_us_max": 81,
+        "current_a": 0.146,
+        "eff_gf_per_w": 4.085,
+        "elec_power_w": 3.55,
+        "fet_temp_c": 25.05,
+        "main_loop_us_max": 145,
+        "motor_temp_c": 23.94,
+        "rpm": 3806.6,
+        "segment": "t10",
+        "throttle": 0.1,
+        "thrust_gf": 12.56,
+        "voltage_v": 24.324
+      },
+      {
+        "cpu_load_pct": 51.4,
+        "ctrl_exec_us_max": 63,
+        "current_a": 0.834,
+        "eff_gf_per_w": 3.701,
+        "elec_power_w": 20.22,
+        "fet_temp_c": 25.38,
+        "main_loop_us_max": 130,
+        "motor_temp_c": 23.55,
+        "rpm": 8705.1,
+        "segment": "t20",
+        "throttle": 0.2,
+        "thrust_gf": 74.25,
+        "voltage_v": 24.255
+      },
+      {
+        "cpu_load_pct": 45.8,
+        "ctrl_exec_us_max": 62,
+        "current_a": 1.951,
+        "eff_gf_per_w": 3.431,
+        "elec_power_w": 47.08,
+        "fet_temp_c": 26.01,
+        "main_loop_us_max": 128,
+        "motor_temp_c": 23.22,
+        "rpm": 12468.7,
+        "segment": "t30",
+        "throttle": 0.3,
+        "thrust_gf": 161.1,
+        "voltage_v": 24.129
+      },
+      {
+        "cpu_load_pct": 47.4,
+        "ctrl_exec_us_max": 58,
+        "current_a": 3.688,
+        "eff_gf_per_w": 3.205,
+        "elec_power_w": 88.28,
+        "fet_temp_c": 26.5,
+        "main_loop_us_max": 129,
+        "motor_temp_c": 23.1,
+        "rpm": 15871.1,
+        "segment": "t40",
+        "throttle": 0.4,
+        "thrust_gf": 282.76,
+        "voltage_v": 23.94
+      },
+      {
+        "cpu_load_pct": 46.8,
+        "ctrl_exec_us_max": 50,
+        "current_a": 5.843,
+        "eff_gf_per_w": 2.868,
+        "elec_power_w": 138.44,
+        "fet_temp_c": 27.19,
+        "main_loop_us_max": 127,
+        "motor_temp_c": 23.13,
+        "rpm": 18600.3,
+        "segment": "t50",
+        "throttle": 0.5,
+        "thrust_gf": 396.97,
+        "voltage_v": 23.693
+      },
+      {
+        "cpu_load_pct": 48.0,
+        "ctrl_exec_us_max": 56,
+        "current_a": 8.704,
+        "eff_gf_per_w": 2.559,
+        "elec_power_w": 203.42,
+        "fet_temp_c": 28.24,
+        "main_loop_us_max": 126,
+        "motor_temp_c": 23.19,
+        "rpm": 21124.0,
+        "segment": "t60",
+        "throttle": 0.6,
+        "thrust_gf": 520.49,
+        "voltage_v": 23.372
+      },
+      {
+        "cpu_load_pct": 47.6,
+        "ctrl_exec_us_max": 55,
+        "current_a": 11.865,
+        "eff_gf_per_w": 2.4,
+        "elec_power_w": 273.04,
+        "fet_temp_c": 29.74,
+        "main_loop_us_max": 133,
+        "motor_temp_c": 23.4,
+        "rpm": 23206.9,
+        "segment": "t70",
+        "throttle": 0.7,
+        "thrust_gf": 654.17,
+        "voltage_v": 23.013
+      },
+      {
+        "cpu_load_pct": 49.2,
+        "ctrl_exec_us_max": 59,
+        "current_a": 15.449,
+        "eff_gf_per_w": 2.119,
+        "elec_power_w": 349.22,
+        "fet_temp_c": 31.45,
+        "main_loop_us_max": 134,
+        "motor_temp_c": 23.91,
+        "rpm": 25167.4,
+        "segment": "t80",
+        "throttle": 0.8,
+        "thrust_gf": 740.15,
+        "voltage_v": 22.605
+      },
+      {
+        "cpu_load_pct": 52.4,
+        "ctrl_exec_us_max": 69,
+        "current_a": 19.546,
+        "eff_gf_per_w": 1.885,
+        "elec_power_w": 432.69,
+        "fet_temp_c": 33.5,
+        "main_loop_us_max": 147,
+        "motor_temp_c": 24.41,
+        "rpm": 26927.7,
+        "segment": "t90",
+        "throttle": 0.9,
+        "thrust_gf": 815.52,
+        "voltage_v": 22.137
+      },
+      {
+        "cpu_load_pct": 47.6,
+        "ctrl_exec_us_max": 64,
+        "current_a": 24.099,
+        "eff_gf_per_w": 1.636,
+        "elec_power_w": 520.93,
+        "fet_temp_c": 35.58,
+        "main_loop_us_max": 141,
+        "motor_temp_c": 24.87,
+        "rpm": 28461.8,
+        "segment": "t100",
+        "throttle": 1.0,
+        "thrust_gf": 852.05,
+        "voltage_v": 21.616
+      }
+    ],
+    "summary": {
+      "bemf_timeout_samples": 0,
+      "best_ctrl_period_us": 6,
+      "demag_events": 0,
+      "idle_loop_rate_hz": 58607.1,
+      "max_cpu_load_pct": 54.7,
+      "max_current_a": 26.06,
+      "max_fet_temp_c": 36.94,
+      "max_motor_temp_c": 25.17,
+      "max_thrust_gf": 960,
+      "n_samples": 6600,
+      "peak_efficiency_gf_per_w": 4.085,
+      "perf_sample_count": 6600,
+      "stand_sample_count": 6600,
+      "telem_sample_count": 0,
+      "worst_ctrl_exec_us": 678,
+      "worst_ctrl_exec_us_steady": 81,
+      "worst_ctrl_period_us": 680,
+      "worst_main_loop_us": 742,
+      "worst_main_loop_us_steady": 147
+    }
+  }
+}

--- a/hwci/baselines/README.md
+++ b/hwci/baselines/README.md
@@ -1,0 +1,26 @@
+# Baselines
+
+Committed performance baselines, one JSON per target, e.g.
+`ARK_4IN1_F051.json`. Each is the metrics snapshot of a known-good run that the
+hardware-CI gate compares new runs against (see `hwci baseline-save` and
+`hwci ci --baseline ...`).
+
+These are **rig- and device-specific** (motor, prop, battery, ambient). Capture
+on your own bench and commit:
+
+```
+hwci ci --profile efficiency_sweep --config rig.yaml --out runs/baseline
+hwci baseline-save runs/baseline --out baselines/ARK_4IN1_F051.json
+```
+
+While no baseline file exists, `hwci ci --baseline ...` warns and skips the
+gate instead of failing, so the first run (or a `save_baseline` workflow
+dispatch) can bootstrap it.
+
+Baselines are stamped with `format_version`, the run meta (target, profile),
+and per-channel sample coverage; the comparison fails on identity mismatch, on
+any missing/NaN gated metric, and on collapsed channel coverage — a baseline
+captured with a dead SWD or telemetry channel would otherwise gate nothing.
+
+Re-baseline deliberately (and note why in the commit) when the motor/prop/setup
+changes or after an intentional, validated performance change.

--- a/hwci/config/rig.example.yaml
+++ b/hwci/config/rig.example.yaml
@@ -1,0 +1,69 @@
+# Example rig configuration for the AM32 hardware-CI harness.
+# Copy to rig.yaml on the test bench and edit for your wiring.
+#
+# A rig file always describes HARDWARE: every backend must be set to a real
+# backend or the explicit "none" (channel absent on this bench). Simulator
+# backends and unknown keys/values are rejected - a typo must fail loudly,
+# never silently degrade a hardware run. For a fully simulated run use
+# `hwci run/ci --sim` (no rig file needed).
+
+# --- firmware / build ---
+target: ARK_4IN1_F051          # AM32 build target (FILE_NAME in Inc/targets.h)
+# repo_root: /home/test/AM32   # defaults to the repo this package lives in
+# obj_dir: /home/test/AM32/obj
+# elf_path:                    # auto: newest obj/AM32_<target>_*.elf
+# app_load_addr: 0x08001000    # default matches Mcu/f051 ldscript (app above bootloader)
+
+# --- debug probe (reads CPU load / loop times over SWD) ---
+debugger_backend: openocd      # openocd | none
+openocd_bin: openocd
+# openocd_configs:             # default: interface/stlink.cfg + target/stm32f0x.cfg
+#   - interface/stlink.cfg     #   (one channel of the ARK 4IN1 10-pin debug header:
+#   - target/stm32f0x.cfg      #    wire ST-Link to the SWDIO/SWCLK pair you test)
+# openocd_search_dirs: []      # extra -s dirs if using custom cfgs
+# For J-Link instead, supply interface/jlink.cfg here (M0 has no SWO, so this is
+# still background-memory-read based, not trace).
+
+# --- ESC telemetry (KISS serial, the ARK target has USE_SERIAL_TELEMETRY) ---
+telem_backend: serial          # serial | none
+telem_port: /dev/esc-telem     # udev symlink recommended (see scripts/99-hwci.rules)
+telem_baud: 115200
+
+# --- throttle source (what drives the ESC signal wire) ---
+throttle_backend: flightstand  # flightstand | external
+# For an external DShot/PWM generator instead:
+# throttle_backend: external
+# throttle_port: /dev/esc-throttle
+# throttle_baud: 115200
+
+# --- thrust stand (Tyto Robotics Flight Stand 50) ---
+# The Flight Stand Software runs on Windows only. On a Linux bench, run it on
+# a Windows PC on the same network, launched with "--remote", and set
+# stand_host to that PC's IP. The signal ids below are Tyto InputType enum
+# values from flight_stand_api_v1.proto; set a channel to null if your bench
+# lacks that sensor.
+stand_backend: grpc            # grpc | none (perf-only bench: none + throttle external)
+stand_host: 127.0.0.1          # machine running the Flight Stand Software
+stand_port: 50051
+stand_signals:
+  thrust: 11                   # FORCE_FZ
+  torque: 14                   # TORQUE_MZ
+  rpm: 15                      # ROTATION_SPEED_FREQUENCY (rad/s over the API)
+  voltage: 6                   # VOLTAGE_HV_INPUT
+  current: 8                   # CURRENT_HALL_CURRENT
+  esc_output: 0                # index into ESC-type outputs, sorted by name
+  esc_min: 1000.0              # raw value of the lowest real throttle step
+  esc_max: 2000.0              # raw value of full throttle
+  # esc_zero: 0.0              # REQUIRED for DShot: AM32 arms only on DShot 0,
+                               #   and 1-47 are commands that must never be
+                               #   emitted (DShot: esc_zero 0, esc_min 48,
+                               #   esc_max 2047). Omit for standard PWM.
+  thrust_is_grams: false       # gRPC API is SI (Newtons)
+  rpm_is_rad_per_s: true       # gRPC API reports rotation in rad/s
+
+# --- device under test ---
+# pole_pairs is authoritative here (recorded into each run's meta and used for
+# the eRPM->RPM conversion); test profiles do not carry motor properties.
+motor_name: "T-Motor F60 Pro V"
+pole_pairs: 7
+prop: "HQ 5x4.3x3"

--- a/hwci/hwci/__init__.py
+++ b/hwci/hwci/__init__.py
@@ -1,0 +1,12 @@
+"""AM32 hardware-in-the-loop CI harness for the ARK 4IN1 ESC.
+
+This package builds and flashes AM32 firmware, drives a motor on a Tyto Robotics
+Flight Stand, and simultaneously reads firmware timing/CPU-load instrumentation
+off the STM32F051 (Cortex-M0) over SWD, then turns the captured data into
+metrics, baselines and pass/fail reports.
+
+See hwci/README.md for the architecture and the rationale behind reading an
+instrumented RAM struct (the M0 has no SWO/ITM/DWT trace hardware).
+"""
+
+__version__ = "0.1.0"

--- a/hwci/hwci/__main__.py
+++ b/hwci/hwci/__main__.py
@@ -1,0 +1,6 @@
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hwci/hwci/baseline.py
+++ b/hwci/hwci/baseline.py
@@ -1,0 +1,238 @@
+"""Baseline storage and regression comparison.
+
+Comparison FAILS CLOSED: a gated metric that is missing, ``None``, or ``NaN``
+on either side fails its check. A dead instrumentation channel (loose SWD
+cable, unplugged telemetry wire, misconfigured backend) produces empty metrics,
+and an empty metric must read as "cannot prove no regression", never as PASS.
+Channel-coverage checks additionally verify that every channel that was alive
+when the baseline was captured is still alive in the current run.
+"""
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+FORMAT_VERSION = 1
+
+# Instrumentation channels whose per-run sample coverage is gated.
+_CHANNELS = ("perf", "stand", "telem")
+
+
+@dataclass
+class Thresholds:
+    """Pass/fail gates relative to the baseline."""
+    # peak & per-point g/W may drop this much. History, all measured on the
+    # ARK 4IN1 + JS Technology 2306 1800KV + HQProp 5136 bench:
+    #   - 3% initial guess, then 15%, then 25%: successive same-firmware
+    #     repeatability checks kept swinging 8-20% per point. Root cause
+    #     turned out to be prop-wake impingement on the stand's mounting
+    #     plate (5" disc entirely inside the plate footprint, wake blowing
+    #     into it) - cancelling ~75% of true thrust and buffeting the load
+    #     cell (per-sample CV 55-66%).
+    #   - back to 15% after the prop was reversed to exhaust into free air:
+    #     four interleaved captures (2 firmwares x 2 runs) show worst
+    #     gated-point (>= 20W) run-to-run spread of 9.8%, so 15% is ~1.5x
+    #     the observed worst case. Tighten further only with more repeat
+    #     captures demonstrating headroom.
+    efficiency_drop_pct: float = 15.0
+    # g/W below this magnitude is load-cell noise (no-prop rig): efficiency is
+    # not a meaningful signal there and is not gated (the check reports "not
+    # gated" instead of flapping on noise around zero).
+    efficiency_floor_gf_per_w: float = 0.5
+    # Below this baseline electrical power, thrust/power is dominated by
+    # measurement noise even WITH a prop (observed: 10% throttle at 2.3W
+    # swung -73% run-to-run; 20% throttle at 19W swung -20%) - the ratio of
+    # two small noisy numbers, not a meaningful efficiency figure. Applies to
+    # per-point checks AND to which points count toward "peak efficiency"
+    # (excluding them keeps peak from being hijacked by the noisiest point).
+    efficiency_min_power_w: float = 20.0
+    ctrl_exec_increase_pct: float = 15.0   # worst control-loop exec time
+    # Absolute slack for the loop-time gates: allowed even when the relative
+    # gate is tighter (a 20us baseline must not fail on +4us of jitter).
+    ctrl_exec_abs_us_slack: float = 45.0
+    cpu_load_increase_pts: float = 10.0    # percentage-POINT increase allowed
+    main_loop_increase_pct: float = 25.0
+    allow_new_demag: bool = False          # demag_events must not exceed baseline
+    min_coverage_fraction: float = 0.5     # channel coverage vs baseline coverage
+
+
+def save_baseline(metrics: dict, path: str | Path, meta: dict | None = None) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(
+        {"format_version": FORMAT_VERSION, "meta": meta or {},
+         "metrics": metrics}, indent=2, sort_keys=True))
+    return path
+
+
+def load_baseline(path: str | Path) -> dict:
+    return json.loads(Path(path).read_text())
+
+
+def _check(name, baseline, current, ok, note=""):
+    return {"name": name, "baseline": baseline, "current": current,
+            "pass": bool(ok), "note": note}
+
+
+def _nan(x) -> bool:
+    return isinstance(x, float) and math.isnan(x)
+
+
+def _missing(x) -> bool:
+    return x is None or _nan(x)
+
+
+def _worse_is_lower(baseline, current, drop_pct):
+    """current must not fall below baseline by more than drop_pct.
+
+    The allowance is ``abs(baseline) * pct`` (not ``baseline * pct``) so a
+    negative baseline compares sanely - with the naive form an identical
+    negative value fails its own baseline (found by self-comparing the first
+    hardware baseline).
+    """
+    if _missing(baseline) or _missing(current):
+        return False  # fail closed: cannot prove no regression
+    return current >= baseline - abs(baseline) * drop_pct / 100.0
+
+
+def _worse_is_higher(baseline, current, inc_pct, abs_slack=None):
+    """current must not exceed baseline by more than inc_pct (relative) or
+    abs_slack (absolute), whichever allows MORE - the absolute term is a
+    noise floor for small baselines, not a cap on the value itself."""
+    if _missing(baseline) or _missing(current):
+        return False  # fail closed
+    limit = baseline * (1.0 + inc_pct / 100.0)
+    if abs_slack is not None:
+        limit = max(limit, baseline + abs_slack)
+    return current <= limit
+
+
+def compare(current: dict, baseline: dict, thr: Thresholds | None = None,
+            current_meta: dict | None = None) -> dict:
+    thr = thr or Thresholds()
+    base = baseline["metrics"] if "metrics" in baseline else baseline
+    cs, bs = current["summary"], base["summary"]
+    checks = []
+
+    # Identity: a baseline captured for another target/profile must not gate
+    # this run (renamed profiles / new board revs otherwise mis-compare).
+    bmeta = baseline.get("meta", {}) if isinstance(baseline.get("meta"), dict) else {}
+    if current_meta:
+        for key in ("target", "profile"):
+            b, c = bmeta.get(key), current_meta.get(key)
+            if b and c:
+                checks.append(_check(
+                    f"baseline_{key}", b, c, b == c, "identities must match"))
+
+    def _eff_check(name, b, c, power_w=None):
+        """g/W gate with two noise floors, both learned from the bench:
+        a baseline captured without a prop has efficiency values that are
+        load-cell noise around zero (magnitude floor), and even WITH a prop
+        low-power points are a ratio of two small noisy numbers (power
+        floor: 10% throttle at 2.3W swung -73% run-to-run on an unchanged
+        firmware/hardware repeat capture)."""
+        if not _missing(b) and abs(b) < thr.efficiency_floor_gf_per_w:
+            return _check(name, b, c, True,
+                          f"baseline |g/W| < {thr.efficiency_floor_gf_per_w} "
+                          "(no-prop noise): not gated")
+        if power_w is not None and not _missing(power_w) and power_w < thr.efficiency_min_power_w:
+            return _check(name, b, c, True,
+                          f"baseline power {power_w:.1f}W < "
+                          f"{thr.efficiency_min_power_w}W: not gated")
+        return _check(name, b, c, _worse_is_lower(b, c, thr.efficiency_drop_pct),
+                      f"<= {thr.efficiency_drop_pct}% drop; missing fails")
+
+    # per-point efficiency: gate every segment present in either side; a
+    # steady segment that vanished from the current run fails closed. Needed
+    # here (ahead of the peak check below) because "peak efficiency" for the
+    # gate is recomputed from these points, not trusted from the summary
+    # scalar - see that check for why.
+    base_pts = {p["segment"]: p for p in base.get("steady_points", [])}
+    cur_pts = {p["segment"]: p for p in current.get("steady_points", [])}
+
+    # peak_efficiency_gf_per_w: recomputed from steady_points restricted to
+    # baseline power >= efficiency_min_power_w, NOT taken from the summary
+    # scalar. "Peak" is a max() over all throttle points, and a max amplifies
+    # whichever point is noisiest - on the bench the literal peak was always
+    # the lowest-power point (10% throttle, 2.3W), so gating the raw scalar
+    # gated pure noise every time. Falls back to the scalar for baselines
+    # captured before steady_points existed.
+    if base_pts and cur_pts:
+        base_gate_pts = [p for p in base_pts.values()
+                         if not _missing(p.get("elec_power_w"))
+                         and p["elec_power_w"] >= thr.efficiency_min_power_w]
+        cur_gate_pts = [p for p in cur_pts.values()
+                        if not _missing(p.get("elec_power_w"))
+                        and p["elec_power_w"] >= thr.efficiency_min_power_w]
+        b_peak = max((p["eff_gf_per_w"] for p in base_gate_pts), default=None)
+        c_peak = max((p["eff_gf_per_w"] for p in cur_gate_pts), default=None)
+    else:
+        b_peak = bs.get("peak_efficiency_gf_per_w")
+        c_peak = cs.get("peak_efficiency_gf_per_w")
+    checks.append(_eff_check("peak_efficiency_gf_per_w", b_peak, c_peak))
+
+    # Loop-time gates use the STEADY-window worst case when the baseline has
+    # it: the raw run-max is dominated by motor start/stop transients that
+    # vary 30%+ run-to-run (705 vs 950 us observed back-to-back on the bench)
+    # and would make the gate flap. Old baselines without the steady keys
+    # fall back to the run-max.
+    for base_key, pct, slack in (
+            ("worst_ctrl_exec_us", thr.ctrl_exec_increase_pct,
+             thr.ctrl_exec_abs_us_slack),
+            ("worst_main_loop_us", thr.main_loop_increase_pct, None)):
+        key = (f"{base_key}_steady"
+               if not _missing(bs.get(f"{base_key}_steady")) else base_key)
+        slack_note = f" or +{slack}us" if slack is not None else ""
+        checks.append(_check(
+            key, bs.get(key), cs.get(key),
+            _worse_is_higher(bs.get(key), cs.get(key), pct, slack),
+            f"<= +{pct}%{slack_note}; missing fails"))
+
+    # CPU load: percentage-point increase
+    b_cpu, c_cpu = bs.get("max_cpu_load_pct"), cs.get("max_cpu_load_pct")
+    cpu_ok = (not _missing(b_cpu) and not _missing(c_cpu)
+              and c_cpu <= b_cpu + thr.cpu_load_increase_pts)
+    checks.append(_check("max_cpu_load_pct", b_cpu, c_cpu, cpu_ok,
+                         f"<= +{thr.cpu_load_increase_pts} points; missing fails"))
+
+    # demag events
+    b_dem, c_dem = bs.get("demag_events"), cs.get("demag_events")
+    dem_ok = (thr.allow_new_demag
+              or (not _missing(b_dem) and not _missing(c_dem) and c_dem <= b_dem))
+    checks.append(_check("demag_events", b_dem, c_dem, dem_ok,
+                         "must not exceed baseline; missing fails"))
+
+    # Instrumentation coverage: every channel alive at baseline capture must
+    # still deliver samples now, else its gates above passed vacuously... which
+    # they no longer do, but this check names the DEAD CHANNEL explicitly.
+    b_tot, c_tot = bs.get("n_samples"), cs.get("n_samples")
+    for chan in _CHANNELS:
+        b_n = bs.get(f"{chan}_sample_count")
+        if _missing(b_n) or not b_n or _missing(b_tot) or not b_tot:
+            continue  # baseline (older format) has no coverage info
+        c_n = cs.get(f"{chan}_sample_count")
+        b_ratio = b_n / b_tot
+        c_ratio = (c_n / c_tot) if not _missing(c_n) and not _missing(c_tot) and c_tot else None
+        ok = c_ratio is not None and c_ratio >= thr.min_coverage_fraction * b_ratio
+        checks.append(_check(
+            f"{chan}_coverage", round(b_ratio, 3),
+            round(c_ratio, 3) if c_ratio is not None else None, ok,
+            f">= {thr.min_coverage_fraction}x baseline coverage "
+            f"(dead {chan} channel?)"))
+
+    # per-point efficiency (base_pts/cur_pts computed above, ahead of the
+    # peak check): gate every segment present in either side; a steady
+    # segment that vanished from the current run fails closed.
+    for label, bp in base_pts.items():
+        p = cur_pts.get(label)
+        if p is None:
+            checks.append(_check(f"eff@{label}", bp.get("eff_gf_per_w"), None,
+                                 False, "segment missing from current run"))
+            continue
+        checks.append(_eff_check(f"eff@{label}", bp.get("eff_gf_per_w"),
+                                 p.get("eff_gf_per_w"), bp.get("elec_power_w")))
+
+    passed = all(c["pass"] for c in checks)
+    return {"passed": passed, "checks": checks, "thresholds": asdict(thr)}

--- a/hwci/hwci/build.py
+++ b/hwci/hwci/build.py
@@ -1,0 +1,49 @@
+"""Firmware build helpers (wrap the AM32 Makefile)."""
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class BuildArtifacts:
+    elf: Path
+    bin: Path
+    hex: Path
+
+
+def find_artifact(obj_dir: Path, target: str, ext: str) -> Path | None:
+    """Newest ``obj/AM32_<target>_*.<ext>`` build artifact, or None.
+
+    The single place that knows the Makefile's artifact naming; RigConfig's
+    ELF resolution reuses it so the flashed binary and the parsed ELF can
+    never be picked by two different rules.
+    """
+    hits = sorted(obj_dir.glob(f"AM32_{target}_*.{ext}"))
+    return hits[-1] if hits else None
+
+
+def build_firmware(repo_root: str | Path, target: str, *,
+                   hwci_perf: bool = True, jobs: int = 4,
+                   arm_sdk_prefix: str | None = None,
+                   extra_make_args: list[str] | None = None) -> BuildArtifacts:
+    """Run ``make <target>`` (with HWCI_PERF=1 by default) and return artifacts."""
+    repo_root = Path(repo_root)
+    cmd = ["make", target, f"-j{jobs}"]
+    if hwci_perf:
+        cmd.append("HWCI_PERF=1")
+    if arm_sdk_prefix:
+        cmd.append(f"ARM_SDK_PREFIX={arm_sdk_prefix}")
+    if extra_make_args:
+        cmd += extra_make_args
+    proc = subprocess.run(cmd, cwd=repo_root, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"firmware build failed (rc={proc.returncode}):\n"
+            f"{proc.stdout[-2000:]}\n{proc.stderr[-2000:]}")
+    obj = repo_root / "obj"
+    elf, binf, hexf = (find_artifact(obj, target, e) for e in ("elf", "bin", "hex"))
+    if elf is None or binf is None:
+        raise RuntimeError(f"build produced no artifacts for {target} in {obj}")
+    return BuildArtifacts(elf=elf, bin=binf, hex=hexf)

--- a/hwci/hwci/cli.py
+++ b/hwci/hwci/cli.py
@@ -1,0 +1,368 @@
+"""Command-line interface for the AM32 hardware-CI harness.
+
+Examples
+--------
+  hwci profiles                         # list built-in test profiles
+  hwci selftest                         # run ci_smoke in the simulator
+  hwci run --profile efficiency_sweep --sim --out runs/sweep
+  hwci analyze runs/sweep
+  hwci baseline-save runs/sweep --out baselines/ARK_4IN1_F051.json
+  hwci ci --profile ci_smoke --config rig.yaml \
+          --baseline baselines/ARK_4IN1_F051.json --out runs/ci
+
+Mode selection: a run is SIMULATED only when ``--sim`` is passed or no
+``--config`` is given; a rig config always means hardware (and refuses
+simulator backends), so a typo can never silently gate simulated data.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from . import baseline as bl
+from . import metrics as metricsmod
+from . import report as reportmod
+from .config import (Profile, RigConfig, list_profiles, load_profile,
+                     load_rig, profile_from_dict, profile_to_dict)
+from .model import RunResult
+from .runner import (DEFAULT_MIN_CELL_VOLTAGE, build_live_sources,
+                     build_sim_sources, run_profile)
+
+
+def _git_sha(repo_root: str) -> str | None:
+    try:
+        out = subprocess.run(["git", "rev-parse", "--short", "HEAD"],
+                             cwd=repo_root, capture_output=True, text=True)
+        return out.stdout.strip() or None
+    except Exception:
+        return None
+
+
+def _make_meta(rig: RigConfig, profile: Profile, mode: str,
+               extra: dict | None = None) -> dict:
+    meta = {
+        "target": rig.target,
+        "profile": profile.name,
+        # Full profile definition: the run dir stays analyzable even if the
+        # profile YAML changes later (or was a custom file path).
+        "profile_def": profile_to_dict(profile),
+        "mode": mode,  # "sim" | "hw" - shown in the report, never inferred later
+        "pole_pairs": rig.pole_pairs,
+        "git_sha": _git_sha(rig.repo_root),
+        "motor": rig.motor_name,
+        "prop": rig.prop,
+        "timestamp": datetime.now().isoformat(timespec="seconds"),
+    }
+    if extra:
+        meta.update(extra)
+    return meta
+
+
+def _use_sim(args) -> bool:
+    """Simulation is explicit: --sim, or no rig config at all."""
+    return bool(getattr(args, "sim", False)) or not getattr(args, "config", None)
+
+
+def _default_out(profile_name: str, sim: bool) -> Path:
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    tag = "sim" if sim else "hw"
+    return Path("runs") / f"{profile_name}-{tag}-{stamp}"
+
+
+def _profile_for(result: RunResult) -> Profile:
+    """The exact profile a run was made with (from meta), else by name."""
+    pd = result.meta.get("profile_def")
+    if pd:
+        return profile_from_dict(pd)
+    return load_profile(result.meta.get("profile", "ci_smoke"))
+
+
+def _load_baseline(path: str | None) -> dict | None:
+    if not path:
+        return None
+    p = Path(path)
+    if not p.exists():
+        print(f"WARNING: baseline {p} not found - skipping the regression "
+              "gate (bootstrap run? capture one with 'hwci baseline-save')",
+              file=sys.stderr)
+        return None
+    return bl.load_baseline(p)
+
+
+def _execute(rig: RigConfig, profile: Profile, sim: bool, *,
+             realtime: bool | None = None,
+             battery_cells: int | None = None,
+             min_cell_voltage: float = DEFAULT_MIN_CELL_VOLTAGE,
+             tare: bool = True) -> RunResult:
+    """Build sources, run the profile, always close sources.
+
+    The battery and tare pre-flight steps only apply to hardware: a simulated
+    pack doesn't represent any real cell count and simulated load cells have
+    no zero drift, so neither is ever passed to the simulator sources.
+    """
+    sources = (build_sim_sources(rig, profile) if sim
+               else build_live_sources(rig, profile, battery_cells=battery_cells,
+                                       min_cell_voltage=min_cell_voltage,
+                                       tare=tare))
+    # Recorded so a drifting thrust offset in saved data can be told apart
+    # from "this run simply wasn't tared".
+    tared = bool(tare) and not sim and rig.stand_backend == "grpc"
+    try:
+        return run_profile(
+            profile, sources,
+            realtime=(not sim) if realtime is None else realtime,
+            meta=_make_meta(rig, profile, "sim" if sim else "hw",
+                           extra={"battery_cells": battery_cells,
+                                  "tared": tared}))
+    finally:
+        sources.close()
+
+
+def _analyze_and_report(run_dir: Path, result: RunResult, profile: Profile,
+                        baseline_path: str | None, no_plots: bool):
+    """Compute metrics, write metrics.json + report.md, gate vs baseline."""
+    m = metricsmod.compute(result, profile)
+    (run_dir / "metrics.json").write_text(json.dumps(m, indent=2))
+    baseline = _load_baseline(baseline_path)
+    comparison = (bl.compare(m, baseline, current_meta=result.meta)
+                  if baseline is not None else None)
+    reportmod.write_report(run_dir, m, comparison, result.meta,
+                           plots=not no_plots)
+    return m, comparison
+
+
+def _verdict_rc(result: RunResult, comparison: dict | None) -> int:
+    """Exit code: 2 aborted (never trust the data), 1 gate FAIL, 0 PASS."""
+    if result.meta.get("aborted"):
+        print(f"ABORTED: {result.meta['aborted']}", file=sys.stderr)
+        return 2
+    if comparison is not None:
+        print("VERDICT:", "PASS" if comparison["passed"] else "FAIL")
+        return 0 if comparison["passed"] else 1
+    return 0
+
+
+# --------------------------------------------------------------------------
+def cmd_profiles(args) -> int:
+    for name in list_profiles():
+        p = load_profile(name)
+        print(f"{name:22s} {p.duration_s:5.0f}s  {p.description.strip().splitlines()[0]}")
+    return 0
+
+
+def cmd_selftest(args) -> int:
+    rig = RigConfig()
+    profile = load_profile(args.profile)
+    sources = build_sim_sources(rig, profile, demag_prone=True)
+    try:
+        result = run_profile(profile, sources, realtime=False,
+                             meta=_make_meta(rig, profile, "sim"))
+    finally:
+        sources.close()
+    m = metricsmod.compute(result, profile)
+    print(json.dumps(m["summary"], indent=2))
+    print(f"\n{len(result.rows)} samples, "
+          f"{len(m['steady_points'])} steady points, "
+          f"{m['demag']['event_count']} demag events")
+    return 0
+
+
+def cmd_build(args) -> int:
+    from .build import build_firmware
+    rig = load_rig(args.config)
+    target = args.target or rig.target
+    arts = build_firmware(rig.repo_root, target, hwci_perf=not args.no_perf,
+                          arm_sdk_prefix=args.arm_sdk_prefix)
+    print(f"built {arts.elf}\n      {arts.bin}")
+    return 0
+
+
+def cmd_flash(args) -> int:
+    from .build import build_firmware
+    from .debugger.openocd import OpenOcdDebugger
+    rig = load_rig(args.config)
+    if args.bin:
+        binf = Path(args.bin)
+    else:
+        arts = build_firmware(rig.repo_root, rig.target,
+                              hwci_perf=not args.no_perf,
+                              arm_sdk_prefix=args.arm_sdk_prefix)
+        binf = arts.bin
+    dbg = OpenOcdDebugger(rig.openocd_configs, openocd_bin=rig.openocd_bin,
+                          search_dirs=rig.openocd_search_dirs)
+    dbg.flash(str(binf), rig.app_load_addr)
+    print(f"flashed {binf} @ 0x{rig.app_load_addr:08x}")
+    return 0
+
+
+def cmd_run(args) -> int:
+    sim = _use_sim(args)
+    rig = load_rig(args.config) if args.config else RigConfig()
+    profile = load_profile(args.profile)
+    result = _execute(rig, profile, sim,
+                      realtime=True if args.realtime else None,
+                      battery_cells=args.battery_cells,
+                      min_cell_voltage=args.min_cell_voltage,
+                      tare=not args.no_tare)
+    out = Path(args.out) if args.out else _default_out(profile.name, sim)
+    result.save(out)
+    print(f"saved {len(result.rows)} samples to {out}")
+    return _verdict_rc(result, None)
+
+
+def cmd_analyze(args) -> int:
+    result = RunResult.load(args.run_dir)
+    m = metricsmod.compute(result, _profile_for(result))
+    (Path(args.run_dir) / "metrics.json").write_text(json.dumps(m, indent=2))
+    print(json.dumps(m["summary"], indent=2))
+    return 0
+
+
+def cmd_baseline_save(args) -> int:
+    result = RunResult.load(args.run_dir)
+    m = metricsmod.compute(result, _profile_for(result))
+    out = args.out or f"baselines/{result.meta.get('target', 'unknown')}.json"
+    bl.save_baseline(m, out, meta=result.meta)
+    print(f"baseline saved to {out}")
+    return 0
+
+
+def cmd_report(args) -> int:
+    result = RunResult.load(args.run_dir)
+    _, comparison = _analyze_and_report(
+        Path(args.run_dir), result, _profile_for(result),
+        args.baseline, args.no_plots)
+    print(f"report written to {Path(args.run_dir) / 'report.md'}")
+    return _verdict_rc(result, comparison)
+
+
+def cmd_ci(args) -> int:
+    sim = _use_sim(args)
+    rig = load_rig(args.config) if args.config else RigConfig()
+    profile = load_profile(args.profile)
+    out = Path(args.out) if args.out else _default_out(profile.name, sim)
+
+    if not sim:
+        from .build import build_firmware
+        arts = build_firmware(rig.repo_root, rig.target, hwci_perf=True,
+                              arm_sdk_prefix=args.arm_sdk_prefix)
+        if rig.debugger_backend == "openocd":
+            from .debugger.openocd import OpenOcdDebugger
+            dbg = OpenOcdDebugger(rig.openocd_configs, openocd_bin=rig.openocd_bin,
+                                  search_dirs=rig.openocd_search_dirs)
+            dbg.flash(str(arts.bin), rig.app_load_addr)
+            dbg.close()
+        else:
+            print("WARNING: debugger_backend is not 'openocd' - firmware was "
+                  "built but NOT flashed; testing whatever is on the target",
+                  file=sys.stderr)
+        rig.elf_path = str(arts.elf)
+
+    result = _execute(rig, profile, sim,
+                      battery_cells=args.battery_cells,
+                      min_cell_voltage=args.min_cell_voltage,
+                      tare=not args.no_tare)
+    result.save(out)
+
+    m, comparison = _analyze_and_report(out, result, profile,
+                                        args.baseline, args.no_plots)
+    print(json.dumps(m["summary"], indent=2))
+    return _verdict_rc(result, comparison)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="hwci", description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    def add_common(sp):
+        sp.add_argument("--config", help="rig config YAML (hardware run); "
+                                         "omit for the built-in simulator")
+
+    def add_preflight(sp):
+        sp.add_argument("--battery-cells", type=int, metavar="N",
+                        help="LiPo cell count under test (e.g. 6 for a 6S "
+                             "pack); if given, refuses to start when pack "
+                             "voltage is below N * --min-cell-voltage "
+                             "(hardware only - ignored under --sim)")
+        sp.add_argument("--min-cell-voltage", type=float, metavar="V",
+                        default=DEFAULT_MIN_CELL_VOLTAGE,
+                        help="per-cell cutoff volts for --battery-cells "
+                             f"(default: {DEFAULT_MIN_CELL_VOLTAGE})")
+        sp.add_argument("--no-tare", action="store_true",
+                        help="skip the automatic pre-run load-cell tare "
+                             "(hardware runs tare by default, with the ESC "
+                             "signal held at zero throttle so AM32's "
+                             "no-signal beacon beeps can't shake the cells "
+                             "mid-tare)")
+
+    sp = sub.add_parser("profiles", help="list test profiles")
+    sp.set_defaults(func=cmd_profiles)
+
+    sp = sub.add_parser("selftest", help="run a profile in the simulator")
+    sp.add_argument("--profile", default="ci_smoke")
+    sp.set_defaults(func=cmd_selftest)
+
+    sp = sub.add_parser("build", help="build firmware (HWCI_PERF=1)")
+    add_common(sp)
+    sp.add_argument("--target")
+    sp.add_argument("--no-perf", action="store_true", help="build without instrumentation")
+    sp.add_argument("--arm-sdk-prefix")
+    sp.set_defaults(func=cmd_build)
+
+    sp = sub.add_parser("flash", help="flash firmware via OpenOCD")
+    add_common(sp)
+    sp.add_argument("--bin", help="bin to flash (default: build it)")
+    sp.add_argument("--no-perf", action="store_true")
+    sp.add_argument("--arm-sdk-prefix")
+    sp.set_defaults(func=cmd_flash)
+
+    sp = sub.add_parser("run", help="run a profile and save the data")
+    add_common(sp)
+    add_preflight(sp)
+    sp.add_argument("--profile", required=True)
+    sp.add_argument("--sim", action="store_true", help="force the simulator")
+    sp.add_argument("--realtime", action="store_true", help="pace sim in real time")
+    sp.add_argument("--out")
+    sp.set_defaults(func=cmd_run)
+
+    sp = sub.add_parser("analyze", help="compute metrics for a run dir")
+    sp.add_argument("run_dir")
+    sp.set_defaults(func=cmd_analyze)
+
+    sp = sub.add_parser("baseline-save", help="save a run's metrics as the baseline")
+    sp.add_argument("run_dir")
+    sp.add_argument("--out")
+    sp.set_defaults(func=cmd_baseline_save)
+
+    sp = sub.add_parser("report", help="write a Markdown report for a run dir")
+    sp.add_argument("run_dir")
+    sp.add_argument("--baseline")
+    sp.add_argument("--no-plots", action="store_true")
+    sp.set_defaults(func=cmd_report)
+
+    sp = sub.add_parser("ci", help="build+flash+run+analyze+gate (full pipeline)")
+    add_common(sp)
+    add_preflight(sp)
+    sp.add_argument("--profile", default="ci_smoke")
+    sp.add_argument("--baseline")
+    sp.add_argument("--sim", action="store_true")
+    sp.add_argument("--arm-sdk-prefix")
+    sp.add_argument("--out")
+    sp.add_argument("--no-plots", action="store_true")
+    sp.set_defaults(func=cmd_ci)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hwci/hwci/config.py
+++ b/hwci/hwci/config.py
@@ -1,0 +1,201 @@
+"""Rig and test-profile configuration (YAML-backed).
+
+Rig configs from files are validated STRICTLY: unknown keys and unknown
+backend values are errors, and simulator backends are rejected in a rig file.
+A typo must never silently turn a hardware run into a simulated one (or drop a
+channel) while CI reports green - use the explicit ``--sim`` flag to simulate.
+"""
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+from .build import find_artifact
+from .debugger.openocd import APP_LOAD_ADDR, DEFAULT_CONFIGS
+from .flightstand.base import SafetyLimits
+
+PROFILES_DIR = Path(__file__).parent / "profiles"
+DEFAULT_TARGET = "ARK_4IN1_F051"
+
+# Allowed backend values. "sim" entries are valid only for the built-in
+# default RigConfig (offline runs); load_rig() rejects them in a rig file.
+BACKEND_CHOICES: dict[str, set[str]] = {
+    "debugger_backend": {"openocd", "sim", "none"},
+    "telem_backend": {"serial", "sim", "none"},
+    "throttle_backend": {"flightstand", "external", "sim"},
+    "stand_backend": {"grpc", "sim", "none"},
+}
+_SIM_ONLY = {"sim"}
+
+
+@dataclass
+class Segment:
+    """One phase of a test profile."""
+    label: str
+    throttle: float           # target throttle, 0..1
+    duration_s: float
+    ramp: bool = False        # ramp linearly from the previous throttle
+    steady: bool = False      # use this segment for steady-state metrics
+
+
+@dataclass
+class Profile:
+    name: str
+    description: str = ""
+    sample_rate_hz: float = 100.0
+    arm_settle_s: float = 2.0
+    segments: list[Segment] = field(default_factory=list)
+    safety: SafetyLimits = field(default_factory=SafetyLimits)
+    # analysis knobs
+    steady_tail_fraction: float = 0.5   # use last half of a steady segment
+    demag_commutation_spike: float = 3.0  # x median commutation interval
+    demag_rpm_drop_fraction: float = 0.25  # rpm fell >25% while throttle high
+    # Offline fallback only: on a rig the motor's pole pairs come from
+    # RigConfig (recorded into the run meta), not from the test profile.
+    pole_pairs: int = 7
+
+    @property
+    def duration_s(self) -> float:
+        return sum(s.duration_s for s in self.segments)
+
+
+def _safety_from(d: dict) -> SafetyLimits:
+    d = d or {}
+    return SafetyLimits(
+        max_thrust_n=d.get("max_thrust_n"),
+        max_current_a=d.get("max_current_a"),
+        max_rpm=d.get("max_rpm"),
+        max_voltage_v=d.get("max_voltage_v"),
+        max_motor_temp_c=d.get("max_motor_temp_c"),
+    )
+
+
+def profile_from_dict(d: dict) -> Profile:
+    segs = [Segment(label=s.get("label", f"seg{i}"),
+                    throttle=float(s["throttle"]),
+                    duration_s=float(s["duration_s"]),
+                    ramp=bool(s.get("ramp", False)),
+                    steady=bool(s.get("steady", False)))
+            for i, s in enumerate(d.get("segments", []))]
+    return Profile(
+        name=d["name"],
+        description=d.get("description", ""),
+        sample_rate_hz=float(d.get("sample_rate_hz", 100.0)),
+        arm_settle_s=float(d.get("arm_settle_s", 2.0)),
+        segments=segs,
+        safety=_safety_from(d.get("safety")),
+        steady_tail_fraction=float(d.get("steady_tail_fraction", 0.5)),
+        demag_commutation_spike=float(d.get("demag_commutation_spike", 3.0)),
+        demag_rpm_drop_fraction=float(d.get("demag_rpm_drop_fraction", 0.25)),
+        pole_pairs=int(d.get("pole_pairs", 7)),
+    )
+
+
+def profile_to_dict(profile: Profile) -> dict:
+    """Serialize a Profile (inverse of :func:`profile_from_dict`).
+
+    Stored in each run's ``meta.json`` so a run directory is self-describing:
+    analysis re-uses the exact profile the run was made with, even if the
+    profile YAML changed since (or was a custom file path).
+    """
+    return dataclasses.asdict(profile)
+
+
+def load_profile(name_or_path: str) -> Profile:
+    """Load a profile by built-in name (in profiles/) or by file path."""
+    p = Path(name_or_path)
+    if not p.exists():
+        cand = PROFILES_DIR / f"{name_or_path}.yaml"
+        if cand.exists():
+            p = cand
+        else:
+            raise FileNotFoundError(
+                f"profile {name_or_path!r} not found "
+                f"(looked in {PROFILES_DIR} and as a path)")
+    return profile_from_dict(yaml.safe_load(p.read_text()))
+
+
+def list_profiles() -> list[str]:
+    return sorted(p.stem for p in PROFILES_DIR.glob("*.yaml"))
+
+
+@dataclass
+class RigConfig:
+    """How the host reaches the hardware. Defaults are the offline simulator."""
+    target: str = DEFAULT_TARGET
+    repo_root: str = str(Path(__file__).resolve().parents[2])
+    obj_dir: str | None = None              # default <repo_root>/obj
+    elf_path: str | None = None             # default: glob obj for the target
+
+    debugger_backend: str = "sim"           # "openocd" | "none" (| "sim" offline)
+    openocd_configs: list[str] = field(
+        default_factory=lambda: list(DEFAULT_CONFIGS))
+    openocd_search_dirs: list[str] = field(default_factory=list)
+    openocd_bin: str = "openocd"
+    app_load_addr: int = APP_LOAD_ADDR
+
+    telem_backend: str = "sim"              # "serial" | "none" (| "sim" offline)
+    telem_port: str = "/dev/ttyUSB0"
+    telem_baud: int = 115200
+
+    throttle_backend: str = "sim"           # "flightstand" | "external" (| "sim")
+    throttle_port: str = "/dev/ttyACM0"
+    throttle_baud: int = 115200
+
+    stand_backend: str = "sim"              # "grpc" | "none" (| "sim" offline)
+    stand_host: str = "127.0.0.1"
+    stand_port: int = 50051
+    stand_signals: dict = field(default_factory=dict)
+
+    motor_name: str = "sim-motor"
+    pole_pairs: int = 7                     # the motor under test (authoritative)
+    prop: str = "sim-prop"
+
+    def resolved_obj_dir(self) -> Path:
+        return Path(self.obj_dir) if self.obj_dir else Path(self.repo_root) / "obj"
+
+    def resolved_elf(self) -> Path | None:
+        if self.elf_path:
+            return Path(self.elf_path)
+        return find_artifact(self.resolved_obj_dir(), self.target, "elf")
+
+    def validate(self, *, allow_sim_backends: bool = True) -> None:
+        for key, choices in BACKEND_CHOICES.items():
+            value = getattr(self, key)
+            if value not in choices:
+                raise ValueError(
+                    f"rig config: {key} = {value!r} is not one of "
+                    f"{sorted(choices)}")
+            if not allow_sim_backends and value in _SIM_ONLY:
+                raise ValueError(
+                    f"rig config: {key} = 'sim' is not allowed in a rig file; "
+                    "use a real backend or 'none' (or run with --sim for a "
+                    "fully simulated run)")
+        if self.throttle_backend == "flightstand" and self.stand_backend == "none":
+            raise ValueError(
+                "rig config: throttle_backend 'flightstand' needs a stand "
+                "(stand_backend 'grpc'); use throttle_backend 'external' on a "
+                "stand-less bench")
+
+
+def load_rig(path: str | None) -> RigConfig:
+    if not path:
+        return RigConfig()
+    data = yaml.safe_load(Path(path).read_text()) or {}
+    known = {f.name for f in dataclasses.fields(RigConfig)}
+    unknown = sorted(set(data) - known)
+    if unknown:
+        raise ValueError(
+            f"rig config {path}: unknown key(s) {unknown}; "
+            f"valid keys: {sorted(known)}")
+    cfg = RigConfig()
+    for key, value in data.items():
+        setattr(cfg, key, value)
+    # A rig FILE describes hardware: simulator backends in it are almost
+    # certainly a typo'd or half-edited config, and silently simulating a
+    # "hardware" run is the worst possible failure mode.
+    cfg.validate(allow_sim_backends=False)
+    return cfg

--- a/hwci/hwci/debugger/__init__.py
+++ b/hwci/hwci/debugger/__init__.py
@@ -1,0 +1,3 @@
+"""Debugger backends for reading firmware instrumentation over SWD."""
+from .base import Debugger, DebuggerError, MockDebugger  # noqa: F401
+from .openocd import OpenOcdDebugger  # noqa: F401

--- a/hwci/hwci/debugger/base.py
+++ b/hwci/hwci/debugger/base.py
@@ -1,0 +1,77 @@
+"""Debugger backend abstraction.
+
+A :class:`Debugger` flashes firmware and performs *background* (non-halting)
+memory reads/writes over SWD while the MCU runs. That background access is the
+only way to read CPU-load / loop-time data off the STM32F051, whose Cortex-M0
+core has no SWO/ITM/DWT trace hardware.
+
+Both the OpenOCD (ST-Link) backend and a J-Link backend would implement this
+interface; :class:`MockDebugger` implements it in-process for offline tests and
+simulator runs.
+"""
+from __future__ import annotations
+
+import abc
+
+
+class DebuggerError(RuntimeError):
+    pass
+
+
+class Debugger(abc.ABC):
+    @abc.abstractmethod
+    def flash(self, bin_path: str, load_addr: int) -> None:
+        """Program ``bin_path`` at ``load_addr`` and reset into it."""
+
+    @abc.abstractmethod
+    def read_memory(self, addr: int, length: int) -> bytes:
+        """Read ``length`` bytes from target RAM without halting the core."""
+
+    @abc.abstractmethod
+    def write_u32(self, addr: int, value: int) -> None:
+        """Write a 32-bit word to target RAM without halting the core."""
+
+    def reset_run(self) -> None:  # optional
+        pass
+
+    def close(self) -> None:  # optional
+        pass
+
+    def __enter__(self) -> "Debugger":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+
+class MockDebugger(Debugger):
+    """In-memory debugger backed by a flat byte buffer.
+
+    Used by the simulator and unit tests. ``base`` is the address that maps to
+    the start of the buffer; reads/writes outside the buffer raise.
+    """
+
+    def __init__(self, base: int = 0x20000000, size: int = 0x2000):
+        self.base = base
+        self.mem = bytearray(size)
+        self.flashed: list[tuple[str, int]] = []
+
+    # --- helpers for tests/simulator ---------------------------------
+    def poke(self, addr: int, data: bytes) -> None:
+        off = addr - self.base
+        if off < 0 or off + len(data) > len(self.mem):
+            raise DebuggerError(f"address 0x{addr:08x} out of mock range")
+        self.mem[off:off + len(data)] = data
+
+    # --- Debugger interface ------------------------------------------
+    def flash(self, bin_path: str, load_addr: int) -> None:
+        self.flashed.append((bin_path, load_addr))
+
+    def read_memory(self, addr: int, length: int) -> bytes:
+        off = addr - self.base
+        if off < 0 or off + length > len(self.mem):
+            raise DebuggerError(f"read 0x{addr:08x}+{length} out of mock range")
+        return bytes(self.mem[off:off + length])
+
+    def write_u32(self, addr: int, value: int) -> None:
+        self.poke(addr, (value & 0xFFFFFFFF).to_bytes(4, "little"))

--- a/hwci/hwci/debugger/openocd.py
+++ b/hwci/hwci/debugger/openocd.py
@@ -1,0 +1,210 @@
+"""OpenOCD (ST-Link) debugger backend.
+
+Drives a persistent ``openocd`` process and talks to its Tcl-RPC port (6666) to
+read/write target memory while the firmware runs. Cortex-M memory access goes
+through the AHB-AP and does not require halting the core, which is what makes
+non-intrusive CPU-load/loop-time sampling possible (the same mechanism VS Code
+"live watch" uses; note ``-gdb-max-connections`` in Mcu/f051/openocd.cfg).
+
+Flashing is done with a separate one-shot ``openocd`` invocation so the
+persistent read session is never left in a halted state.
+
+This backend cannot be unit-tested without hardware; the offline test path uses
+:class:`hwci.debugger.base.MockDebugger`. The Tcl-RPC framing and command set
+here follow the documented OpenOCD interface.
+"""
+from __future__ import annotations
+
+import collections
+import shutil
+import socket
+import struct
+import subprocess
+import threading
+import time
+
+from .base import Debugger, DebuggerError
+
+# OpenOCD Tcl-RPC terminates every command and reply with this byte.
+_RPC_SEP = b"\x1a"
+
+# Default config matching Mcu/f051/openocd.cfg (ST-Link + STM32F0 target).
+DEFAULT_CONFIGS = ["interface/stlink.cfg", "target/stm32f0x.cfg"]
+APP_LOAD_ADDR = 0x08001000  # AM32 app sits above the bootloader
+
+
+class OpenOcdDebugger(Debugger):
+    def __init__(
+        self,
+        configs: list[str] | None = None,
+        *,
+        openocd_bin: str = "openocd",
+        tcl_port: int = 6666,
+        search_dirs: list[str] | None = None,
+        connect_timeout: float = 10.0,
+    ):
+        self.configs = configs or list(DEFAULT_CONFIGS)
+        self.openocd_bin = openocd_bin
+        self.tcl_port = tcl_port
+        self.search_dirs = search_dirs or []
+        self.connect_timeout = connect_timeout
+        self._proc: subprocess.Popen | None = None
+        self._sock: socket.socket | None = None
+        self._log_tail: collections.deque[str] = collections.deque(maxlen=200)
+        self._drain_thread: threading.Thread | None = None
+        # The Tcl-RPC socket carries one command/reply at a time; the perf
+        # poller thread and the runner (stat resets at steady tails) both use
+        # it, so serialize access or the reply framing interleaves.
+        self._rpc_lock = threading.Lock()
+        if shutil.which(openocd_bin) is None:
+            raise DebuggerError(f"{openocd_bin!r} not found on PATH")
+
+    # --- config helpers ----------------------------------------------
+    def _base_args(self) -> list[str]:
+        args = [self.openocd_bin]
+        for d in self.search_dirs:
+            args += ["-s", d]
+        for c in self.configs:
+            args += ["-f", c]
+        return args
+
+    # --- flashing (one-shot) -----------------------------------------
+    def flash(self, bin_path: str, load_addr: int = APP_LOAD_ADDR) -> None:
+        cmd = self._base_args() + [
+            "-c", f"program {{{bin_path}}} 0x{load_addr:08x} verify reset exit",
+        ]
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        if proc.returncode != 0:
+            raise DebuggerError(
+                f"flash failed (rc={proc.returncode}):\n{proc.stderr}\n{proc.stdout}")
+
+    # --- persistent read session -------------------------------------
+    def open(self) -> "OpenOcdDebugger":
+        """Start openocd (init, no halt) and connect to the Tcl-RPC port."""
+        cmd = self._base_args() + [
+            "-c", f"tcl_port {self.tcl_port}",
+            "-c", "gdb_port disabled",
+            "-c", "telnet_port disabled",
+            "-c", "init",
+            # leave the core running; only attach for background memory access
+        ]
+        self._proc = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        # openocd logs continuously to stdout. NOBODY reading the pipe kills
+        # the session: once the 64 KiB pipe buffer fills, openocd blocks on
+        # write and every Tcl-RPC call times out from then on (observed on
+        # the bench as the perf channel dying at the same sample every run).
+        # Drain it forever; keep a tail for error diagnostics.
+        self._drain_thread = threading.Thread(
+            target=self._drain_stdout, daemon=True, name="openocd-drain")
+        self._drain_thread.start()
+        self._connect_rpc()
+        # Ensure the core is running (a fresh attach can leave it halted).
+        try:
+            self._rpc("resume")
+        except DebuggerError:
+            pass
+        return self
+
+    def _drain_stdout(self) -> None:
+        proc = self._proc
+        if proc is None or proc.stdout is None:
+            return
+        try:
+            for line in proc.stdout:
+                self._log_tail.append(line.rstrip("\n"))
+        except (OSError, ValueError):
+            pass  # pipe closed on shutdown
+
+    def _connect_rpc(self) -> None:
+        deadline = time.monotonic() + self.connect_timeout
+        last_err: Exception | None = None
+        while time.monotonic() < deadline:
+            try:
+                self._sock = socket.create_connection(
+                    ("127.0.0.1", self.tcl_port), timeout=2.0)
+                return
+            except OSError as e:  # openocd not listening yet
+                last_err = e
+                if self._proc and self._proc.poll() is not None:
+                    time.sleep(0.1)  # let the drain thread catch the tail
+                    out = "\n".join(self._log_tail)
+                    raise DebuggerError(f"openocd exited early:\n{out}")
+                time.sleep(0.2)
+        raise DebuggerError(f"could not connect to openocd Tcl-RPC: {last_err}")
+
+    def _rpc(self, command: str) -> str:
+        with self._rpc_lock:
+            return self._rpc_locked(command)
+
+    def _rpc_locked(self, command: str) -> str:
+        if self._sock is None:
+            raise DebuggerError("RPC session not open; call open() first")
+        try:
+            self._sock.sendall(command.encode() + _RPC_SEP)
+            chunks = bytearray()
+            while _RPC_SEP not in chunks:
+                data = self._sock.recv(4096)
+                if not data:
+                    raise DebuggerError("openocd RPC closed unexpectedly")
+                chunks += data
+        except (socket.timeout, OSError) as e:
+            # One glitched command desyncs the reply framing (the late reply
+            # would be read as the answer to the NEXT command), so a single
+            # hiccup would poison every subsequent read for the rest of the
+            # run. Rebuild the socket - openocd itself is still fine - and
+            # surface the error for this call only (observed on the bench:
+            # one SWD read timeout at motor spin-up killed the whole perf
+            # channel).
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+            self._connect_rpc()
+            raise DebuggerError(f"openocd RPC error for {command!r}: {e}") from e
+        return chunks.split(_RPC_SEP, 1)[0].decode(errors="replace")
+
+    # --- Debugger interface ------------------------------------------
+    def read_memory(self, addr: int, length: int) -> bytes:
+        nwords = (length + 3) // 4
+        # read_memory returns space-separated decimal values (one per word).
+        out = self._rpc(f"read_memory 0x{addr:08x} 32 {nwords}")
+        tokens = out.replace("{", " ").replace("}", " ").split()
+        try:
+            words = [int(t, 0) for t in tokens]
+        except ValueError as e:
+            raise DebuggerError(f"unparseable read_memory reply {out!r}: {e}")
+        if len(words) < nwords:
+            raise DebuggerError(
+                f"short read: wanted {nwords} words, got {len(words)} ({out!r})")
+        return struct.pack(f"<{nwords}I", *words[:nwords])[:length]
+
+    def write_u32(self, addr: int, value: int) -> None:
+        # OpenOCD reports failure IN-BAND: a successful mww replies with an
+        # empty string, a failed one with error text (no exception). Swallowing
+        # it would let e.g. a stats-reset silently no-op.
+        out = self._rpc(f"mww 0x{addr:08x} 0x{value & 0xFFFFFFFF:08x}")
+        if out.strip():
+            raise DebuggerError(f"mww 0x{addr:08x} failed: {out.strip()!r}")
+
+    def reset_run(self) -> None:
+        self._rpc("reset run")
+
+    def close(self) -> None:
+        try:
+            if self._sock is not None:
+                try:
+                    self._rpc("exit")
+                except DebuggerError:
+                    pass
+                self._sock.close()
+        finally:
+            self._sock = None
+            if self._proc is not None:
+                self._proc.terminate()
+                try:
+                    self._proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    self._proc.kill()
+                self._proc = None

--- a/hwci/hwci/elf.py
+++ b/hwci/hwci/elf.py
@@ -1,0 +1,138 @@
+"""Locate the ``hwci_perf`` struct inside a built firmware ELF.
+
+The host never hard-codes a RAM address. It reads the address (and, when DWARF
+is present, the full member layout) straight from the ELF that was flashed, so
+the harness stays correct across firmware revisions and across the four
+identical STM32F051 dies on the ARK 4IN1 (they share one image).
+
+Requires ``pyelftools``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+try:
+    from elftools.elf.elffile import ELFFile
+    _HAVE_ELFTOOLS = True
+except ImportError:  # pragma: no cover - exercised only without the dep
+    _HAVE_ELFTOOLS = False
+
+
+class ElfError(RuntimeError):
+    pass
+
+
+class StructNotFoundError(ElfError):
+    """DWARF is present but the requested struct DIE is not.
+
+    Distinct from "no DWARF at all": callers that soft-skip the layout
+    cross-check when debug info is stripped must still HARD-FAIL here - a
+    renamed/dropped struct is exactly the drift the check exists to catch."""
+
+
+def _require_elftools() -> None:
+    if not _HAVE_ELFTOOLS:
+        raise ElfError(
+            "pyelftools is required to read firmware symbols; "
+            "pip install pyelftools")
+
+
+@dataclass
+class Symbol:
+    name: str
+    address: int
+    size: int
+
+
+def find_symbol(elf_path: str, name: str) -> Symbol:
+    """Return address+size of ``name`` from the ELF symbol table."""
+    _require_elftools()
+    with open(elf_path, "rb") as fh:
+        elf = ELFFile(fh)
+        symtab = elf.get_section_by_name(".symtab")
+        if symtab is None:
+            raise ElfError(f"{elf_path}: no .symtab (build with debug symbols)")
+        matches = [s for s in symtab.iter_symbols() if s.name == name]
+        if not matches:
+            raise ElfError(
+                f"symbol {name!r} not found in {elf_path}; "
+                "is the firmware built with HWCI_PERF=1?")
+        sym = matches[0]
+        return Symbol(name=name,
+                      address=sym["st_value"],
+                      size=sym["st_size"])
+
+
+# Map (DWARF encoding, byte_size) -> struct code, matching perf.FIELDS codes.
+_ENCODING_SIGNED = {5, 6, 0xd}  # DW_ATE_signed / signed_char / (vendor)
+
+
+@dataclass
+class Member:
+    name: str
+    offset: int
+    size: int
+    signed: bool
+
+
+def struct_layout(elf_path: str, type_name: str) -> list[Member]:
+    """Read the member layout of ``struct <type_name>`` from DWARF debug info.
+
+    Returns members in offset order. Raises :class:`ElfError` if the ELF has no
+    DWARF (firmware must be compiled with -g, which AM32 does by default).
+    """
+    _require_elftools()
+    with open(elf_path, "rb") as fh:
+        elf = ELFFile(fh)
+        if not elf.has_dwarf_info():
+            raise ElfError(f"{elf_path}: no DWARF info")
+        dwarf = elf.get_dwarf_info()
+        for cu in dwarf.iter_CUs():
+            for die in cu.iter_DIEs():
+                if die.tag != "DW_TAG_structure_type":
+                    continue
+                name_attr = die.attributes.get("DW_AT_name")
+                if name_attr is None:
+                    continue
+                if name_attr.value.decode("utf-8", "replace") != type_name:
+                    continue
+                return _members_of(die, cu)
+    raise StructNotFoundError(
+        f"struct {type_name!r} not found in DWARF of {elf_path}")
+
+
+def _members_of(struct_die, cu) -> list[Member]:
+    members: list[Member] = []
+    for child in struct_die.iter_children():
+        if child.tag != "DW_TAG_member":
+            continue
+        name = child.attributes["DW_AT_name"].value.decode("utf-8", "replace")
+        offset = child.attributes.get("DW_AT_data_member_location")
+        offset_val = offset.value if offset is not None else 0
+        if isinstance(offset_val, list):  # location expression form
+            # DW_OP_plus_uconst <n> => [0x23, n]
+            offset_val = offset_val[1] if len(offset_val) > 1 else 0
+        size, signed = _base_type(child, cu)
+        members.append(Member(name=name, offset=offset_val,
+                              size=size, signed=signed))
+    members.sort(key=lambda m: m.offset)
+    return members
+
+
+def _base_type(member_die, cu) -> tuple[int, bool]:
+    type_ref = member_die.attributes.get("DW_AT_type")
+    if type_ref is None:
+        return 0, False
+    die = cu.get_DIE_from_refaddr(type_ref.value + cu.cu_offset)
+    # Walk through typedef/const/volatile qualifiers to the base type.
+    while die.tag in ("DW_TAG_typedef", "DW_TAG_const_type",
+                      "DW_TAG_volatile_type"):
+        nxt = die.attributes.get("DW_AT_type")
+        if nxt is None:
+            return 0, False
+        die = cu.get_DIE_from_refaddr(nxt.value + cu.cu_offset)
+    size_attr = die.attributes.get("DW_AT_byte_size")
+    size = size_attr.value if size_attr is not None else 0
+    enc_attr = die.attributes.get("DW_AT_encoding")
+    signed = bool(enc_attr and enc_attr.value in _ENCODING_SIGNED)
+    return size, signed

--- a/hwci/hwci/esc_telem/__init__.py
+++ b/hwci/hwci/esc_telem/__init__.py
@@ -1,0 +1,2 @@
+"""ESC-side telemetry decoding (KISS serial)."""
+from .kiss import KissFrame, KissStream, crc8, encode_frame, parse_frame  # noqa: F401

--- a/hwci/hwci/esc_telem/kiss.py
+++ b/hwci/hwci/esc_telem/kiss.py
@@ -1,0 +1,119 @@
+"""KISS / BLHeli ESC serial telemetry decoding.
+
+AM32 emits a 10-byte KISS telemetry frame on the dedicated telemetry wire
+(``USE_SERIAL_TELEMETRY`` is enabled on the ARK 4IN1 target). The frame is the
+struct ``kiss_telem_pkt_t`` in ``Inc/kiss_telemetry.h``:
+
+    byte 0      int8   temperature, degrees C
+    byte 1..2   u16 BE voltage, centivolts
+    byte 3..4   u16 BE current, centiamps
+    byte 5..6   u16 BE consumption, mAh
+    byte 7..8   u16 BE eRPM / 100
+    byte 9      u8     CRC-8 over bytes 0..8
+
+The CRC-8 matches ``get_crc8``/``update_crc8`` in ``Src/functions.c``
+(polynomial 0x07, init 0x00). There is no start delimiter, so the streaming
+parser resyncs by sliding a 10-byte window until the CRC validates.
+"""
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from typing import Iterator
+
+FRAME_LEN = 10
+
+
+def _crc8_table() -> bytes:
+    table = bytearray(256)
+    for byte in range(256):
+        crc = byte
+        for _ in range(8):
+            crc = ((crc << 1) ^ 0x07) & 0xFF if crc & 0x80 else (crc << 1) & 0xFF
+        table[byte] = crc
+    return bytes(table)
+
+
+_CRC8_TABLE = _crc8_table()
+
+
+def crc8(data: bytes) -> int:
+    """BLHeli/KISS CRC-8 (poly 0x07, init 0x00), matching Src/functions.c.
+
+    Table-driven: the streaming framer runs this once per byte-slide when
+    resynchronising on a noisy line, so the bitwise loop would burn a core.
+    """
+    crc = 0
+    for byte in data:
+        crc = _CRC8_TABLE[crc ^ byte]
+    return crc
+
+
+@dataclass
+class KissFrame:
+    temperature_c: int
+    voltage_v: float
+    current_a: float
+    consumption_mah: int
+    e_rpm: int
+    crc_ok: bool
+
+    def mech_rpm(self, pole_pairs: int) -> float:
+        return self.e_rpm / pole_pairs if pole_pairs else 0.0
+
+
+def parse_frame(data: bytes) -> KissFrame:
+    """Parse exactly one 10-byte frame. ``crc_ok`` flags CRC validity."""
+    if len(data) < FRAME_LEN:
+        raise ValueError(f"need {FRAME_LEN} bytes, got {len(data)}")
+    temp, volt_cv, cur_ca, cons, erpm100, crc = struct.unpack(
+        ">bHHHHB", data[:FRAME_LEN])
+    return KissFrame(
+        temperature_c=temp,
+        voltage_v=volt_cv / 100.0,
+        current_a=cur_ca / 100.0,
+        consumption_mah=cons,
+        e_rpm=erpm100 * 100,
+        crc_ok=(crc == crc8(data[:FRAME_LEN - 1])),
+    )
+
+
+def encode_frame(*, temperature_c: int, voltage_cv: int, current_ca: int,
+                 consumption_mah: int, erpm100: int) -> bytes:
+    """Build one CRC'd 10-byte frame (inverse of :func:`parse_frame`).
+
+    The single owner of the wire layout for producers (simulator, tests) so
+    an encoder can never drift from the parser."""
+    body = struct.pack(">bHHHH",
+                       max(-128, min(127, temperature_c)),
+                       voltage_cv & 0xFFFF, current_ca & 0xFFFF,
+                       consumption_mah & 0xFFFF, erpm100 & 0xFFFF)
+    return body + bytes([crc8(body)])
+
+
+class KissStream:
+    """Incremental framer for the KISS byte stream.
+
+    Feed raw bytes from the serial port with :meth:`feed`; it yields every
+    CRC-valid frame found. Because the protocol is delimiter-less, a window that
+    fails CRC is advanced by a single byte to resynchronise.
+    """
+
+    def __init__(self) -> None:
+        self._buf = bytearray()
+
+    def feed(self, data: bytes) -> Iterator[KissFrame]:
+        self._buf.extend(data)
+        while len(self._buf) >= FRAME_LEN:
+            window = bytes(self._buf[:FRAME_LEN])
+            # CRC first: on a misaligned/noisy line the framer slides one byte
+            # at a time, and unpacking + constructing a KissFrame per slide
+            # would dominate the telemetry thread.
+            if crc8(window[:FRAME_LEN - 1]) == window[FRAME_LEN - 1]:
+                del self._buf[:FRAME_LEN]
+                yield parse_frame(window)
+            else:
+                del self._buf[:1]  # resync
+
+    def reset(self) -> None:
+        self._buf.clear()

--- a/hwci/hwci/flightstand/__init__.py
+++ b/hwci/hwci/flightstand/__init__.py
@@ -1,0 +1,4 @@
+"""Flight Stand backends."""
+from .base import SafetyLimits, StandSafetyTripped, StandSample, ThrustStand  # noqa: F401
+from .grpc_client import FlightStandGrpc, SignalMap  # noqa: F401
+from .simulator import SimulatedStand  # noqa: F401

--- a/hwci/hwci/flightstand/base.py
+++ b/hwci/hwci/flightstand/base.py
@@ -1,0 +1,127 @@
+"""Thrust-stand backend abstraction.
+
+A :class:`ThrustStand` represents a Tyto Robotics Flight Stand (50, or any of
+the family) and provides throttle control + synchronized force/electrical
+measurement. The real backend talks gRPC to the Flight Stand Software; the
+simulator implements the same interface for offline development and tests.
+
+Units are SI internally (Newtons, N*m, RPM, V, A). ``grams-force`` and
+``g/W`` (the usual drone efficiency figure) are derived properties.
+"""
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+
+G0 = 9.80665  # standard gravity, m/s^2
+
+
+class StandSafetyTripped(RuntimeError):
+    """A profile safety limit was breached; the run must abort immediately."""
+
+
+@dataclass
+class StandSample:
+    t: float            # host monotonic timestamp, seconds
+    throttle: float     # last commanded throttle, 0..1 (echoed)
+    thrust_n: float
+    torque_nm: float
+    rpm: float          # mechanical RPM
+    voltage_v: float
+    current_a: float
+    motor_temp_c: float | None = None  # optional probe (None = not fitted)
+    fet_temp_c: float | None = None
+
+    @property
+    def elec_power_w(self) -> float:
+        return self.voltage_v * self.current_a
+
+    @property
+    def mech_power_w(self) -> float:
+        omega = self.rpm * 2.0 * 3.141592653589793 / 60.0
+        return self.torque_nm * omega
+
+    @property
+    def thrust_gf(self) -> float:
+        return self.thrust_n / G0 * 1000.0
+
+    @property
+    def efficiency_gf_per_w(self) -> float:
+        p = self.elec_power_w
+        return self.thrust_gf / p if p > 1e-6 else 0.0
+
+    @property
+    def motor_efficiency(self) -> float:
+        p = self.elec_power_w
+        return self.mech_power_w / p if p > 1e-6 else 0.0
+
+
+@dataclass
+class SafetyLimits:
+    """Cutoffs enforced host-side by the runner on every sample (see
+    :func:`hwci.runner.enforce_safety`); a breach aborts the test immediately.
+    Backends may ALSO enforce them (the simulator does; the vendor Flight
+    Stand Software has its own UI cutoffs), but the runner check is the one
+    that is guaranteed to exist on every rig."""
+    max_thrust_n: float | None = None
+    max_current_a: float | None = None
+    max_rpm: float | None = None
+    max_voltage_v: float | None = None
+    max_motor_temp_c: float | None = None
+
+    def check(self, *, thrust_n: float | None = None,
+              current_a: float | None = None, rpm: float | None = None,
+              voltage_v: float | None = None,
+              temp_c: float | None = None) -> None:
+        """Raise :class:`StandSafetyTripped` if any provided value exceeds
+        its limit. ``None`` values (channel not available) are skipped."""
+        def _over(value, limit):
+            return value is not None and limit is not None and value > limit
+        if _over(thrust_n, self.max_thrust_n):
+            raise StandSafetyTripped(
+                f"thrust {thrust_n:.2f} N > limit {self.max_thrust_n:.2f} N")
+        if _over(current_a, self.max_current_a):
+            raise StandSafetyTripped(
+                f"current {current_a:.1f} A > limit {self.max_current_a:.1f} A")
+        if _over(rpm, self.max_rpm):
+            raise StandSafetyTripped(
+                f"rpm {rpm:.0f} > limit {self.max_rpm:.0f}")
+        if _over(voltage_v, self.max_voltage_v):
+            raise StandSafetyTripped(
+                f"voltage {voltage_v:.2f} V > limit {self.max_voltage_v:.2f} V")
+        if _over(temp_c, self.max_motor_temp_c):
+            raise StandSafetyTripped(
+                f"temp {temp_c:.0f} C > limit {self.max_motor_temp_c:.0f} C")
+
+
+class ThrustStand(abc.ABC):
+    @abc.abstractmethod
+    def open(self) -> "ThrustStand":
+        ...
+
+    @abc.abstractmethod
+    def set_throttle(self, throttle: float) -> None:
+        """Command throttle in [0, 1]."""
+
+    @abc.abstractmethod
+    def read_sample(self) -> StandSample:
+        ...
+
+    def set_safety_limits(self, limits: SafetyLimits) -> None:  # optional
+        pass
+
+    def deactivate(self) -> None:  # optional: drop the ESC signal (line low)
+        pass
+
+    def tare(self) -> None:  # optional: zero the load cells
+        pass
+
+    def close(self) -> None:  # optional
+        pass
+
+    def __enter__(self) -> "ThrustStand":
+        return self.open()
+
+    def __exit__(self, *exc) -> None:
+        self.set_throttle(0.0)
+        self.close()

--- a/hwci/hwci/flightstand/grpc_client.py
+++ b/hwci/hwci/flightstand/grpc_client.py
@@ -1,0 +1,326 @@
+"""Real Flight Stand gRPC backend (Tyto Robotics Flight Stand Software API v1).
+
+Mapped against ``flight_stand_api_v1.proto`` from
+https://gitlab.com/TytoRobotics/flightstand-api (the pre-compiled Python stubs
+in ``languages/python`` of that repo must be importable, e.g. via a ``.pth``
+file in the venv).
+
+The Tyto model: *boards* (USB measurement units) expose *inputs* (sensors,
+identified by ``InputType``: FORCE_FZ=11 is thrust) and *outputs* (the ESC
+signal, ``OutputType.ESC``). The latest value of every signal comes back in
+one ``ListSamples`` round trip; throttle is commanded with ``UpdateOutput``
+on the output's ``output_target`` field (a µs-style value, 1000-2000 for
+standard PWM).
+
+The Flight Stand Software runs on Windows only. For a Linux bench, run it on
+a Windows PC on the same network, launched with ``--remote``, and point
+``stand_host`` at that PC. Units over the API are SI: thrust in Newtons,
+rotation speed in rad/s (converted to RPM here).
+
+The numeric ids in :class:`SignalMap` ARE Tyto ``InputType`` enum values, so
+a rig file maps channels without touching code; ``esc_output`` indexes the
+ESC-type outputs sorted by resource name.
+"""
+from __future__ import annotations
+
+import importlib
+import math
+import time
+
+from dataclasses import dataclass
+
+from .base import SafetyLimits, StandSample, ThrustStand
+
+
+@dataclass
+class SignalMap:
+    """Maps StandSample fields to Tyto ``InputType`` enum values.
+
+    Defaults follow the proto: FORCE_FZ=11 thrust, TORQUE_MZ=14, ROTATION_
+    SPEED_FREQUENCY=15 (rad/s), VOLTAGE_HV_INPUT=6, CURRENT_HALL_CURRENT=8.
+    Set a channel to ``null``/None in the rig file if the bench lacks it;
+    reads then report 0.0 and the metrics coverage gate flags it.
+    """
+    thrust: int = 11
+    torque: int | None = 14
+    rpm: int | None = 15
+    voltage: int | None = 6
+    current: int | None = 8
+    # Optional temperature channels. Values may be an InputType enum int, or
+    # a string: an input resource name ("/boards/COM3/inputs/29", stable per
+    # board) or a raw signal name ("/signals/37", renumbers on reconnect -
+    # prefer the input name).
+    motor_temp: int | str | None = None
+    fet_temp: int | str | None = None
+    # Output (actuator) used to command throttle, and its raw range.
+    esc_output: int = 0
+    esc_min: float = 1000.0   # raw value of the LOWEST real throttle step
+    esc_max: float = 2000.0   # raw value of full throttle
+    # Raw value for throttle == 0. Leave None where zero throttle IS esc_min
+    # (standard PWM: 1000 us). For DShot it must be 0: AM32 only arms on
+    # sustained DShot 0 (what an FC sends while disarmed), values 1-47 are
+    # DShot COMMANDS that must never be emitted (a ramp sweeping them could
+    # trigger beacons or even settings changes), and real throttle starts at
+    # 48. So DShot: esc_zero=0, esc_min=48, esc_max=2047.
+    esc_zero: float | None = None
+    thrust_is_grams: bool = False  # gRPC API is SI: Newtons
+    rpm_is_rad_per_s: bool = True  # gRPC API reports rotation in rad/s
+
+
+G0 = 9.80665
+RADS_TO_RPM = 60.0 / (2.0 * math.pi)
+
+
+def _k_to_c(kelvin: float | None) -> float | None:
+    return kelvin - 273.15 if kelvin is not None else None
+
+
+class _StubAdapter:
+    """The only proto-aware surface, mapped to Tyto's FlightStand service."""
+
+    RPC_TIMEOUT_S = 2.0
+
+    def __init__(self, host: str, port: int, pb2: str, pb2_grpc: str):
+        try:
+            self._pb2 = importlib.import_module(pb2)
+            self._pb2_grpc = importlib.import_module(pb2_grpc)
+            from google.protobuf import field_mask_pb2
+            import grpc
+        except ImportError as e:
+            raise RuntimeError(
+                "Flight Stand gRPC stubs / grpcio not importable "
+                f"({e}). Clone https://gitlab.com/TytoRobotics/flightstand-api "
+                "and make languages/python importable (pip install grpcio "
+                "protobuf, then add a .pth file pointing at it).") from e
+        self._grpc = grpc
+        self._field_mask_pb2 = field_mask_pb2
+        self._channel = grpc.insecure_channel(f"{host}:{port}")
+        self._stub = self._make_stub()
+        self._sig_by_type: dict[int, str] = {}
+        self._esc_outputs: list = []
+        # Fail fast with an actionable message if the core is not running.
+        try:
+            self._stub.GetServerStatus(self._pb2.GetServerStatusRequest(),
+                                       timeout=self.RPC_TIMEOUT_S)
+        except grpc.RpcError as e:
+            raise RuntimeError(
+                f"Flight Stand core not reachable at {host}:{port} "
+                f"({e.code().name}). Start the Flight Stand Software "
+                "(with --remote if it runs on another machine).") from e
+        # A cutoff latched from a previous session blocks output commands.
+        try:
+            self._stub.ClearCutoff(self._pb2.ClearCutoffRequest(),
+                                   timeout=self.RPC_TIMEOUT_S)
+        except grpc.RpcError:
+            pass  # no cutoff to clear
+
+    # --- proto-specific operations ----------------------------------------
+    def _make_stub(self):
+        # The generated grpc module exposes one <ServiceName>Stub class.
+        stub_classes = [v for k, v in vars(self._pb2_grpc).items()
+                        if k.endswith("Stub")]
+        if not stub_classes:
+            raise RuntimeError("no *Stub class found in grpc stubs module")
+        return stub_classes[0](self._channel)
+
+    def list_boards(self):
+        """Boards that are connected and ready."""
+        resp = self._stub.ListBoards(self._pb2.ListBoardsRequest(),
+                                     timeout=self.RPC_TIMEOUT_S)
+        boards = [b for b in resp.boards if b.ready]
+        if not boards:
+            raise RuntimeError(
+                "Flight Stand core is running but reports no ready boards - "
+                "check the stand's USB connections on the machine running "
+                "the Flight Stand Software.")
+        return boards
+
+    def connect_board(self, board) -> None:
+        """USB boards auto-connect; discover the signal/output mapping.
+
+        Inputs and outputs are discovered across ALL ready boards (the
+        Flight Stand 50 enumerates as separate force and power units), so
+        ``board`` only anchors the error message.
+        """
+        ins = self._stub.ListInputs(self._pb2.ListInputsRequest(),
+                                    timeout=self.RPC_TIMEOUT_S).inputs
+        self._sig_by_type = {}
+        self._sig_by_input_name = {}
+        for i in ins:
+            # First input of each type wins, matching the vendor helper's
+            # find_input_by_type().
+            self._sig_by_type.setdefault(int(i.input_type), i.signal_name)
+            self._sig_by_input_name[i.name] = i.signal_name
+
+        outs = self._stub.ListOutputs(self._pb2.ListOutputsRequest(),
+                                      timeout=self.RPC_TIMEOUT_S).outputs
+        self._esc_outputs = sorted(
+            (o for o in outs if o.output_type == self._pb2.ESC and not o.closed),
+            key=lambda o: o.name)
+        if not self._esc_outputs:
+            raise RuntimeError(
+                f"no ESC output found on {board.name} (or any board) - "
+                "cannot command throttle")
+
+    def input_types_available(self) -> dict[int, str]:
+        """InputType -> signal_name map discovered at connect (diagnostics)."""
+        return dict(self._sig_by_type)
+
+    def _resolve(self, sid) -> str | None:
+        """Channel id -> signal name. int = InputType enum; str = input
+        resource name (preferred, stable) or raw /signals/N name."""
+        if isinstance(sid, str):
+            if sid.startswith("/signals/"):
+                return sid
+            return self._sig_by_input_name.get(sid)
+        return self._sig_by_type.get(sid)
+
+    def read_signal(self, signal_id) -> float:
+        return self.read_signals([signal_id]).get(signal_id, 0.0)
+
+    def read_signals(self, signal_ids: list) -> dict:
+        """Latest value for each wanted channel in ONE round trip.
+
+        ``ListSamples`` returns the most recent sample of every signal;
+        inactive samples (sensor off/disconnected) are omitted so the
+        caller's 0.0 default and the coverage gate see a dead channel.
+        """
+        wanted = {}
+        for sid in signal_ids:
+            name = self._resolve(sid)
+            if name is not None:
+                wanted[name] = sid
+        if not wanted:
+            return {}
+        resp = self._stub.ListSamples(self._pb2.ListSamplesRequest(),
+                                      timeout=self.RPC_TIMEOUT_S)
+        out: dict[int, float] = {}
+        for sample in resp.sample_group.samples:
+            t = wanted.get(sample.signal_name)
+            if t is not None and sample.active:
+                out[t] = sample.value
+        return out
+
+    def set_output(self, output_id: int, value: float, *,
+                   active: bool = True) -> None:
+        try:
+            output = self._esc_outputs[output_id]
+        except IndexError:
+            raise RuntimeError(
+                f"esc_output index {output_id} out of range - only "
+                f"{len(self._esc_outputs)} ESC output(s) discovered")
+        target = self._pb2.OutputTarget(active=active, target_value=value,
+                                        rate_limit_per_second=0.0)
+        mask = self._field_mask_pb2.FieldMask(paths=["output_target"])
+        req = self._pb2.UpdateOutputRequest(
+            output=self._pb2.Output(name=output.name, output_target=target),
+            mask=mask)
+        self._stub.UpdateOutput(req, timeout=self.RPC_TIMEOUT_S)
+
+    def tare(self) -> None:
+        self._stub.TareInputs(self._pb2.TareInputsRequest(),
+                              timeout=30.0)  # taring takes a few seconds
+
+    def close_channel(self) -> None:
+        self._channel.close()
+
+
+class FlightStandGrpc(ThrustStand):
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 50051,
+        *,
+        signals: SignalMap | None = None,
+        pb2_module: str = "flight_stand_api_v1_pb2",
+        pb2_grpc_module: str = "flight_stand_api_v1_pb2_grpc",
+        board_index: int = 0,
+    ):
+        self.host = host
+        self.port = port
+        self.signals = signals or SignalMap()
+        self._pb2_module = pb2_module
+        self._pb2_grpc_module = pb2_grpc_module
+        self._board_index = board_index
+        self._api: _StubAdapter | None = None
+        self._throttle = 0.0
+
+    def open(self) -> "FlightStandGrpc":
+        self._api = _StubAdapter(self.host, self.port,
+                                 self._pb2_module, self._pb2_grpc_module)
+        boards = self._api.list_boards()
+        self._api.connect_board(boards[self._board_index])
+        return self
+
+    def set_throttle(self, throttle: float) -> None:
+        throttle = max(0.0, min(1.0, throttle))
+        self._throttle = throttle
+        s = self.signals
+        if throttle <= 0.0 and s.esc_zero is not None:
+            raw = s.esc_zero            # e.g. DShot 0: disarm-idle/motor stop
+        else:
+            raw = s.esc_min + throttle * (s.esc_max - s.esc_min)
+        self._api.set_output(s.esc_output, raw)
+
+    def read_sample(self) -> StandSample:
+        s = self.signals
+        wanted = [sid for sid in (s.thrust, s.torque, s.rpm, s.voltage,
+                                  s.current, s.motor_temp, s.fet_temp)
+                  if sid is not None]
+        values = self._api.read_signals(wanted) if wanted else {}
+
+        def _get(signal_id) -> float:
+            return values.get(signal_id, 0.0) if signal_id is not None else 0.0
+
+        thrust = _get(s.thrust)
+        thrust_n = thrust * G0 / 1000.0 if s.thrust_is_grams else thrust
+        rpm = _get(s.rpm)
+        if s.rpm_is_rad_per_s:
+            rpm *= RADS_TO_RPM
+        return StandSample(
+            t=time.monotonic(),
+            throttle=self._throttle,
+            thrust_n=thrust_n,
+            torque_nm=_get(s.torque),
+            rpm=rpm,
+            voltage_v=_get(s.voltage),
+            current_a=_get(s.current),
+            # None (not 0.0) when unmapped/inactive: a dead temp probe must
+            # read as missing, not as a freezing motor. The API is strict SI,
+            # so temperatures arrive in Kelvin.
+            motor_temp_c=_k_to_c(values.get(s.motor_temp)) if s.motor_temp is not None else None,
+            fet_temp_c=_k_to_c(values.get(s.fet_temp)) if s.fet_temp is not None else None,
+        )
+
+    def set_safety_limits(self, limits: SafetyLimits) -> None:
+        # NOTE: this backend cannot enforce limits itself until the vendor
+        # cutoff-condition RPC is mapped in _StubAdapter. Enforcement happens
+        # in the runner (hwci.runner.enforce_safety) against every sample;
+        # configure the Flight Stand Software's own UI cutoffs as a second
+        # layer.
+        self._limits = limits
+
+    def deactivate(self) -> None:
+        """Drop the ESC signal entirely (output inactive drives logic 0)."""
+        self._api.set_output(self.signals.esc_output, self.signals.esc_min,
+                             active=False)
+
+    def tare(self) -> None:
+        if self._api is not None:
+            self._api.tare()
+
+    def close(self) -> None:
+        if self._api is not None:
+            park = (self.signals.esc_zero if self.signals.esc_zero is not None
+                    else self.signals.esc_min)
+            try:
+                # Park at zero throttle, then drop the signal entirely.
+                self._api.set_output(self.signals.esc_output, park)
+                self._api.set_output(self.signals.esc_output, park,
+                                     active=False)
+            except Exception:
+                pass
+            try:
+                self._api.close_channel()
+            except Exception:
+                pass

--- a/hwci/hwci/flightstand/simulator.py
+++ b/hwci/hwci/flightstand/simulator.py
@@ -1,0 +1,62 @@
+"""Simulated Flight Stand backed by :class:`hwci.sim.RigSimulator`.
+
+Lets the entire harness run end-to-end with no hardware. The same
+:class:`~hwci.sim.RigSimulator` instance also feeds the simulated KISS telemetry
+and perf-struct sources so all three channels stay consistent (see
+:func:`hwci.runner.build_sim_sources`).
+"""
+from __future__ import annotations
+
+import time
+from typing import Callable
+
+from ..sim import MotorParams, RigSimulator
+from .base import SafetyLimits, StandSafetyTripped, StandSample, ThrustStand
+
+__all__ = ["SimulatedStand", "StandSafetyTripped"]
+
+
+class SimulatedStand(ThrustStand):
+    def __init__(
+        self,
+        rig: RigSimulator | None = None,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        fixed_dt: float | None = None,
+        params: MotorParams | None = None,
+    ):
+        self.rig = rig or RigSimulator(params=params or MotorParams())
+        self._clock = clock
+        self._fixed_dt = fixed_dt
+        self._throttle = 0.0
+        self._last_t: float | None = None
+        self._limits = SafetyLimits()
+
+    def open(self) -> "SimulatedStand":
+        self._last_t = self._clock()
+        return self
+
+    def set_throttle(self, throttle: float) -> None:
+        self._throttle = max(0.0, min(1.0, throttle))
+
+    def set_safety_limits(self, limits: SafetyLimits) -> None:
+        self._limits = limits
+
+    def read_sample(self) -> StandSample:
+        now = self._clock()
+        if self._fixed_dt is not None:
+            dt = self._fixed_dt
+        else:
+            dt = 0.0 if self._last_t is None else max(0.0, now - self._last_t)
+        self._last_t = now
+        self.rig.step(dt, self._throttle)
+        sample = self.rig.stand_sample(now)
+        self._check_limits(sample)
+        return sample
+
+    def _check_limits(self, s: StandSample) -> None:
+        self._limits.check(thrust_n=s.thrust_n, current_a=s.current_a,
+                           rpm=s.rpm, voltage_v=s.voltage_v)
+
+    def close(self) -> None:
+        self._throttle = 0.0

--- a/hwci/hwci/metrics.py
+++ b/hwci/hwci/metrics.py
@@ -1,0 +1,323 @@
+"""Compute performance metrics from a run.
+
+Produces three things the baseline/report care about:
+
+* steady-state operating points (thrust, power, efficiency g/W, plus loop time
+  and CPU load at each throttle),
+* worst-case loop timing and CPU load over the whole run,
+* host-side demag / desync detection (firmware bemf-timeout flag, commutation-
+  interval spikes, RPM collapse, and ESC-eRPM vs stand-RPM divergence).
+
+CPU load uses the idle-residual method: the firmware exposes a free-running
+``loop_iters`` counter; its rate (iters/s) is highest when the core is least
+loaded, so ``cpu_load = 1 - rate/idle_rate`` where ``idle_rate`` is the rate
+measured at zero throttle. This is how CPU load is recovered on a Cortex-M0,
+which has no cycle counter.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from .config import Profile
+from .model import RunResult
+
+
+def _col(rows: list[dict], name: str) -> np.ndarray:
+    out = np.full(len(rows), np.nan)
+    for i, r in enumerate(rows):
+        v = r.get(name)
+        if v is not None and v != "":
+            try:
+                out[i] = float(v)
+            except (TypeError, ValueError):
+                pass
+    return out
+
+
+def _loop_iter_rate(t: np.ndarray, iters: np.ndarray) -> np.ndarray:
+    """Per-sample loop-iteration rate (Hz), NaN where undefined."""
+    rate = np.full(len(t), np.nan)
+    dt = np.diff(t)
+    di = np.diff(iters)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        r = np.where((dt > 0) & (di >= 0), di / dt, np.nan)
+    rate[1:] = r
+    return rate
+
+
+def _cpu_load(rows: list[dict]) -> tuple[np.ndarray, float]:
+    # Prefer the timestamp taken at the actual SWD read (perf_host_t) over the
+    # sample-loop schedule time: a host stall between ticks would otherwise
+    # attribute too many loop iterations to too little time and corrupt the
+    # rate for that sample.
+    t_host = _col(rows, "perf_host_t")
+    t = t_host if not np.all(np.isnan(t_host)) else _col(rows, "t")
+    iters = _col(rows, "perf_loop_iters")
+    throttle = _col(rows, "throttle_cmd")
+    running = _col(rows, "perf_running")
+    rate = _loop_iter_rate(t, iters)
+    # Median, not max: one glitched sample must not become the reference the
+    # whole run's load is scaled by.
+    #
+    # The reference must be "motor genuinely stopped" (firmware-reported
+    # perf_running == 0), NOT "commanded throttle below a small cutoff": a
+    # segment that RAMPS UP FROM ZERO (e.g. efficiency_sweep's t10, 0%->10%)
+    # commands throttle under any such cutoff for real, non-idle time while
+    # the motor is actively spinning up and commutating - a genuine load, not
+    # idle. Observed on the bench: lengthening t10's hold pushed these
+    # ramp-up samples from ~37% to ~50% of the throttle-based reference pool,
+    # collapsing the reported idle rate from ~60k to ~46k iters/s and
+    # understating max_cpu_load_pct by 10+ points. perf_running falls back to
+    # the throttle heuristic only for run data recorded before that column
+    # existed.
+    if not np.all(np.isnan(running)):
+        idle_mask = (running == 0) & ~np.isnan(rate)
+    else:
+        idle_mask = (throttle < 0.02) & ~np.isnan(rate)
+    if idle_mask.any():
+        idle_rate = float(np.nanmedian(rate[idle_mask]))
+    elif not np.all(np.isnan(rate)):
+        idle_rate = float(np.nanmedian(rate))
+    else:
+        return np.full(len(rows), np.nan), float("nan")
+    if idle_rate <= 0:
+        return np.full(len(rows), np.nan), idle_rate
+    load = 100.0 * (1.0 - rate / idle_rate)
+    return np.clip(load, 0.0, 100.0), idle_rate
+
+
+def tail_start_index(n: int, fraction: float) -> int:
+    """First index of the trailing ``fraction`` of ``n`` samples.
+
+    The single source of truth for "where does the steady tail begin" -
+    hwci.runner's mid-segment perf-stats reset computes its own tick relative
+    to THIS function (with a safety margin) specifically so the two can never
+    drift apart. They used to be two independently-rounded formulas that
+    disagreed by a tick in some segment lengths, which is exactly the kind of
+    gap a reset-propagation race can hide in.
+    """
+    if n <= 0:
+        return 0
+    return int(n * (1.0 - fraction))
+
+
+def _tail(idx: np.ndarray, fraction: float) -> np.ndarray:
+    if len(idx) == 0:
+        return idx
+    return idx[tail_start_index(len(idx), fraction):]
+
+
+def _nanmean(a: np.ndarray) -> float:
+    return float(np.nanmean(a)) if a.size and not np.all(np.isnan(a)) else float("nan")
+
+
+def compute(run: RunResult, profile: Profile) -> dict:
+    rows = run.rows
+    seg = np.array([r.get("segment") for r in rows], dtype=object)
+    load, idle_rate = _cpu_load(rows)
+
+    thrust_gf = _col(rows, "stand_thrust_gf")
+    current = _col(rows, "stand_current_a")
+    eff = _col(rows, "stand_eff_gf_per_w")
+    stand_rpm = _col(rows, "stand_rpm")
+    stand_v = _col(rows, "stand_voltage_v")
+    stand_pw = _col(rows, "stand_elec_power_w")
+    motor_temp = _col(rows, "stand_motor_temp_c")
+    fet_temp = _col(rows, "stand_fet_temp_c")
+    ctrl_exec = _col(rows, "perf_ctrl_exec_us_max")
+    ctrl_pmax = _col(rows, "perf_ctrl_period_us_max")
+    ctrl_pmin = _col(rows, "perf_ctrl_period_us_min")
+    main_max = _col(rows, "perf_main_loop_us_max")
+    perf_iters = _col(rows, "perf_loop_iters")
+    esc_erpm = _col(rows, "esc_erpm")
+
+    steady_points = []
+    for s in profile.segments:
+        if not s.steady:
+            continue
+        idx = np.where(seg == s.label)[0]
+        tail = _tail(idx, profile.steady_tail_fraction)
+        if tail.size == 0:
+            continue
+        steady_points.append({
+            "segment": s.label,
+            "throttle": s.throttle,
+            "rpm": round(_nanmean(stand_rpm[tail]), 1),
+            "thrust_gf": round(_nanmean(thrust_gf[tail]), 2),
+            "current_a": round(_nanmean(current[tail]), 3),
+            "voltage_v": round(_nanmean(stand_v[tail]), 3),
+            "elec_power_w": round(_nanmean(stand_pw[tail]), 2),
+            "eff_gf_per_w": round(_nanmean(eff[tail]), 3),
+            "ctrl_exec_us_max": _safe_max(ctrl_exec[tail]),
+            "main_loop_us_max": _safe_max(main_max[tail]),
+            "cpu_load_pct": round(_nanmean(load[tail]), 1),
+            "motor_temp_c": round(_nanmean(motor_temp[tail]), 2),
+            "fet_temp_c": round(_nanmean(fet_temp[tail]), 2),
+        })
+
+    demag = detect_demag(run, profile)
+
+    summary = {
+        "max_thrust_gf": _safe_max(thrust_gf),
+        "max_current_a": round(_safe_maxf(current), 2),
+        "peak_efficiency_gf_per_w": round(
+            max((p["eff_gf_per_w"] for p in steady_points), default=float("nan")), 3),
+        "worst_ctrl_exec_us": _safe_max(ctrl_exec),
+        # Steady-window worst case: the runner resets the firmware's sticky
+        # accumulators at each steady tail, so these exclude motor start/stop
+        # transients (which vary 30%+ run-to-run) and are the values the
+        # baseline gate compares.
+        "worst_ctrl_exec_us_steady": max(
+            (p["ctrl_exec_us_max"] for p in steady_points
+             if p.get("ctrl_exec_us_max") is not None), default=None),
+        "worst_ctrl_period_us": _safe_max(ctrl_pmax),
+        "best_ctrl_period_us": _safe_minf(ctrl_pmin),
+        "worst_main_loop_us": _safe_max(main_max),
+        "worst_main_loop_us_steady": max(
+            (p["main_loop_us_max"] for p in steady_points
+             if p.get("main_loop_us_max") is not None), default=None),
+        "max_cpu_load_pct": round(_safe_maxf(load), 1),
+        "idle_loop_rate_hz": round(idle_rate, 1) if idle_rate == idle_rate else None,
+        "demag_events": demag["event_count"],
+        "bemf_timeout_samples": demag["bemf_timeout_samples"],
+        "max_motor_temp_c": _safe_maxf(motor_temp),
+        "max_fet_temp_c": _safe_maxf(fet_temp),
+        # Channel liveness: how many samples each instrumentation channel
+        # actually delivered. The baseline gate fails a run whose coverage
+        # collapsed vs the baseline (dead SWD/telemetry/stand channel).
+        "n_samples": len(rows),
+        "perf_sample_count": int(np.count_nonzero(~np.isnan(perf_iters))),
+        "stand_sample_count": int(np.count_nonzero(~np.isnan(thrust_gf))),
+        "telem_sample_count": int(np.count_nonzero(~np.isnan(esc_erpm))),
+    }
+    return {"summary": summary, "steady_points": steady_points, "demag": demag}
+
+
+def detect_demag(run: RunResult, profile: Profile) -> dict:
+    rows = run.rows
+    throttle = _col(rows, "throttle_cmd")
+    comm = _col(rows, "perf_commutation_interval")
+    bemf = _col(rows, "perf_bemf_timeout")
+    stand_rpm = _col(rows, "stand_rpm")
+    esc_erpm = _col(rows, "esc_erpm")
+    # Pole pairs are a property of the rig's motor; the run meta records the
+    # rig value at run time. profile.pole_pairs is only the offline fallback.
+    pp = int(run.meta.get("pole_pairs") or profile.pole_pairs)
+
+    running = throttle > 0.2
+    comm_running = comm[running & ~np.isnan(comm) & (comm > 0)]
+    median_comm = float(np.median(comm_running)) if comm_running.size else float("nan")
+    spike_thr = median_comm * profile.demag_commutation_spike if median_comm == median_comm else np.inf
+
+    # per-sample anomaly flag
+    flag = np.zeros(len(rows), dtype=bool)
+    bemf_samples = 0
+    spike_samples = 0
+    for i in range(len(rows)):
+        if not running[i]:
+            continue
+        anom = False
+        # bemf_timeout_happened is an incrementing counter in firmware (1, 2,
+        # ... latched at 102 under stuck-rotor protection), not a boolean.
+        if bemf[i] >= 1:
+            bemf_samples += 1
+            anom = True
+        if comm[i] == comm[i] and comm[i] > spike_thr:
+            spike_samples += 1
+            anom = True
+        flag[i] = anom
+
+    # Stand-RPM collapse while commanded throttle is high and NOT being
+    # intentionally reduced: catches desyncs whose transient firmware flags
+    # fall between SWD samples. The reference is the running max RPM seen
+    # since the throttle last decreased, so spool-up after a step never
+    # reads as a collapse.
+    #
+    # The gate must check the THROTTLE TREND (falling vs. not), not just the
+    # size of one tick's change: a smooth multi-second ramp-down moves by a
+    # tiny amount each 10ms tick, so a small-delta check like "< 0.02" never
+    # fires and the reference RPM is never invalidated - actual RPM then
+    # falls (correctly, because the ramp commanded it to) while the stale
+    # peak reference stays pinned at the ramp's starting RPM, eventually
+    # tripping the drop threshold. Observed on the bench: efficiency_sweep's
+    # 4s 100%->0% rampdn flagged a false demag event with zero bemf timeouts,
+    # commutation spikes, or eRPM/stand-RPM mismatch - RPM was tracking
+    # throttle exactly as commanded.
+    rpm_drop_samples = 0
+    frac = profile.demag_rpm_drop_fraction
+    ref_rpm = float("nan")
+    for i in range(len(rows)):
+        high = throttle[i] == throttle[i] and throttle[i] > 0.5
+        not_decreasing = (i > 0 and throttle[i - 1] == throttle[i - 1]
+                          and throttle[i] >= throttle[i - 1] - 1e-6)
+        if not (high and not_decreasing):
+            ref_rpm = float("nan")
+            continue
+        r = stand_rpm[i]
+        if r != r:
+            continue
+        if ref_rpm != ref_rpm:
+            ref_rpm = r
+            continue
+        ref_rpm = max(ref_rpm, r)
+        if ref_rpm > 1000.0 and r < ref_rpm * (1.0 - frac):
+            rpm_drop_samples += 1
+            flag[i] = True
+
+    # debounce contiguous flagged samples into events (close gaps <= 3)
+    events = _events_from_flags(flag, max_gap=3)
+
+    # ESC eRPM vs stand RPM divergence (telemetry desync indicator)
+    mismatch = 0
+    for i in range(len(rows)):
+        if running[i] and esc_erpm[i] == esc_erpm[i] and stand_rpm[i] == stand_rpm[i] \
+                and stand_rpm[i] > 500:
+            esc_mech = esc_erpm[i] / pp
+            if abs(esc_mech - stand_rpm[i]) / stand_rpm[i] > 0.2:
+                mismatch += 1
+
+    return {
+        "event_count": len(events),
+        "events": [{"start_idx": int(a), "end_idx": int(b)} for a, b in events],
+        "bemf_timeout_samples": bemf_samples,
+        "comm_spike_samples": spike_samples,
+        "rpm_drop_samples": rpm_drop_samples,
+        "median_commutation_interval": round(median_comm, 1) if median_comm == median_comm else None,
+        "esc_rpm_mismatch_samples": mismatch,
+    }
+
+
+def _events_from_flags(flag: np.ndarray, max_gap: int = 3) -> list[tuple[int, int]]:
+    events: list[tuple[int, int]] = []
+    start = None
+    gap = 0
+    for i, f in enumerate(flag):
+        if f:
+            if start is None:
+                start = i
+            last = i
+            gap = 0
+        elif start is not None:
+            gap += 1
+            if gap > max_gap:
+                events.append((start, last))
+                start = None
+    if start is not None:
+        events.append((start, last))
+    return events
+
+
+def _safe_max(a: np.ndarray):
+    if a.size and not np.all(np.isnan(a)):
+        return int(np.nanmax(a))
+    return None
+
+
+def _safe_maxf(a: np.ndarray) -> float:
+    return float(np.nanmax(a)) if a.size and not np.all(np.isnan(a)) else float("nan")
+
+
+def _safe_minf(a: np.ndarray):
+    if a.size and not np.all(np.isnan(a)):
+        return int(np.nanmin(a))
+    return None

--- a/hwci/hwci/model.py
+++ b/hwci/hwci/model.py
@@ -1,0 +1,126 @@
+"""Run data model: flat, columnar samples plus run metadata.
+
+A run is a list of flat row dicts (one per sample tick) over a fixed column set,
+serialized as ``samples.csv`` next to a ``meta.json``. Keeping rows flat avoids
+a pandas dependency and makes the metric math trivial with numpy.
+"""
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .esc_telem.kiss import KissFrame
+from .flightstand.base import StandSample
+from .perf import PerfSample
+
+COLUMNS = [
+    "t", "segment", "throttle_cmd",
+    # thrust stand
+    "stand_thrust_n", "stand_thrust_gf", "stand_torque_nm", "stand_rpm",
+    "stand_voltage_v", "stand_current_a", "stand_elec_power_w",
+    "stand_eff_gf_per_w", "stand_motor_temp_c", "stand_fet_temp_c",
+    # ESC KISS telemetry
+    "esc_erpm", "esc_voltage_v", "esc_current_a", "esc_temp_c",
+    # firmware perf struct (perf_host_t = host monotonic clock at the actual
+    # SWD read, so counter-rate math is immune to sample-loop scheduling jitter)
+    "perf_host_t",
+    "perf_ctrl_exec_us_last", "perf_ctrl_exec_us_max",
+    "perf_ctrl_period_us_max", "perf_ctrl_period_us_min",
+    "perf_main_loop_us_max", "perf_loop_iters", "perf_zero_cross_count",
+    "perf_commutation_interval", "perf_commutation_interval_max",
+    "perf_bemf_timeout", "perf_e_rpm",
+    # ESC input/arming state (proves the ESC decoded the throttle protocol)
+    "perf_input", "perf_armed", "perf_running",
+]
+
+
+def make_row(t: float, segment: str, throttle_cmd: float,
+             stand: StandSample | None,
+             telem: KissFrame | None,
+             perf: PerfSample | None) -> dict:
+    row = {c: "" for c in COLUMNS}
+    row["t"] = round(t, 6)
+    row["segment"] = segment
+    row["throttle_cmd"] = round(throttle_cmd, 4)
+    if stand is not None:
+        row.update(
+            stand_thrust_n=round(stand.thrust_n, 5),
+            stand_thrust_gf=round(stand.thrust_gf, 3),
+            stand_torque_nm=round(stand.torque_nm, 6),
+            stand_rpm=round(stand.rpm, 1),
+            stand_voltage_v=round(stand.voltage_v, 3),
+            stand_current_a=round(stand.current_a, 3),
+            stand_elec_power_w=round(stand.elec_power_w, 3),
+            stand_eff_gf_per_w=round(stand.efficiency_gf_per_w, 4),
+        )
+        if stand.motor_temp_c is not None:
+            row["stand_motor_temp_c"] = round(stand.motor_temp_c, 2)
+        if stand.fet_temp_c is not None:
+            row["stand_fet_temp_c"] = round(stand.fet_temp_c, 2)
+    if telem is not None:
+        row.update(
+            esc_erpm=telem.e_rpm,
+            esc_voltage_v=round(telem.voltage_v, 3),
+            esc_current_a=round(telem.current_a, 3),
+            esc_temp_c=telem.temperature_c,
+        )
+    if perf is not None:
+        r = perf.raw
+        if perf.host_monotonic is not None:
+            row["perf_host_t"] = round(perf.host_monotonic, 6)
+        row.update(
+            perf_ctrl_exec_us_last=r["ctrl_exec_us_last"],
+            perf_ctrl_exec_us_max=r["ctrl_exec_us_max"],
+            perf_ctrl_period_us_max=r["ctrl_period_us_max"],
+            perf_ctrl_period_us_min=r["ctrl_period_us_min"],
+            perf_main_loop_us_max=r["main_loop_us_max"],
+            perf_loop_iters=r["loop_iters"],
+            perf_zero_cross_count=r["zero_cross_count"],
+            perf_commutation_interval=r["commutation_interval"],
+            perf_commutation_interval_max=r["commutation_interval_max"],
+            perf_bemf_timeout=r["bemf_timeout_state"],
+            perf_e_rpm=perf.e_rpm,
+            perf_input=r["input"],
+            perf_armed=r["armed"],
+            perf_running=r["running"],
+        )
+    return row
+
+
+@dataclass
+class RunResult:
+    meta: dict = field(default_factory=dict)
+    rows: list[dict] = field(default_factory=list)
+
+    def save(self, run_dir: str | Path) -> Path:
+        run_dir = Path(run_dir)
+        run_dir.mkdir(parents=True, exist_ok=True)
+        with open(run_dir / "samples.csv", "w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=COLUMNS)
+            writer.writeheader()
+            writer.writerows(self.rows)
+        with open(run_dir / "meta.json", "w") as fh:
+            json.dump(self.meta, fh, indent=2, sort_keys=True)
+        return run_dir
+
+    @classmethod
+    def load(cls, run_dir: str | Path) -> "RunResult":
+        run_dir = Path(run_dir)
+        meta = json.loads((run_dir / "meta.json").read_text())
+        rows: list[dict] = []
+        with open(run_dir / "samples.csv", newline="") as fh:
+            for raw in csv.DictReader(fh):
+                rows.append({k: _coerce(v) for k, v in raw.items()})
+        return cls(meta=meta, rows=rows)
+
+
+def _coerce(value: str):
+    if value == "" or value is None:
+        return None
+    try:
+        f = float(value)
+        return int(f) if f.is_integer() else f
+    except ValueError:
+        return value

--- a/hwci/hwci/perf.py
+++ b/hwci/hwci/perf.py
@@ -1,0 +1,152 @@
+"""Decoder for the firmware ``hwci_perf`` instrumentation struct.
+
+This mirrors, byte-for-byte, the C struct defined in ``Inc/hwci_perf.h``. The
+canonical layout below is the source of truth for offline use and tests; on the
+real rig :mod:`hwci.elf` can additionally derive the layout from the ELF's DWARF
+debug info and cross-check it against this table, so a firmware layout change is
+caught instead of silently misread.
+
+All fields are little-endian and naturally aligned (the struct is deliberately
+not packed because Cortex-M0 cannot do unaligned word access).
+"""
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+
+# ASCII "HWC1" little-endian == 0x31435748
+MAGIC = 0x31435748
+VERSION = 1
+
+# (name, struct_code).  Order and codes must match Inc/hwci_perf.h exactly.
+# Pad fields are decoded then dropped from the public dict.
+FIELDS: list[tuple[str, str]] = [
+    ("magic", "I"),
+    ("version", "H"),
+    ("size", "H"),
+    ("ctrl_exec_us_last", "H"),
+    ("ctrl_exec_us_max", "H"),
+    ("ctrl_period_us_last", "H"),
+    ("ctrl_period_us_max", "H"),
+    ("ctrl_period_us_min", "H"),
+    ("main_loop_us_last", "H"),
+    ("main_loop_us_max", "H"),
+    ("input", "H"),
+    ("duty_cycle", "H"),
+    ("e_rpm", "H"),
+    ("voltage_cv", "H"),
+    ("current_ca", "h"),
+    ("temperature_c", "h"),
+    ("bemf_timeout_state", "B"),
+    ("armed", "B"),
+    ("running", "B"),
+    ("_pad0", "B"),
+    ("_pad1", "H"),
+    ("loop_iters", "I"),
+    ("zero_cross_count", "I"),
+    ("commutation_interval", "I"),
+    ("commutation_interval_max", "I"),
+    ("update_count", "I"),
+    ("host_cmd", "I"),
+]
+
+_FORMAT = "<" + "".join(code for _, code in FIELDS)
+SIZE = struct.calcsize(_FORMAT)  # 64 bytes
+_NAMES = [name for name, _ in FIELDS]
+_PUBLIC = [name for name in _NAMES if not name.startswith("_pad")]
+
+# Host command values understood by the firmware (see Inc/hwci_perf.h).
+CMD_NONE = 0
+CMD_RESET_STATS = 0xA5
+
+# Byte offset of host_cmd within the struct, for the debugger write-back.
+HOST_CMD_OFFSET = sum(struct.calcsize(code) for name, code in FIELDS
+                      if _NAMES.index(name) < _NAMES.index("host_cmd"))
+
+
+class PerfDecodeError(ValueError):
+    """Raised when a buffer cannot be decoded as a valid hwci_perf struct."""
+
+
+@dataclass
+class PerfSample:
+    """One decoded snapshot of the firmware instrumentation struct."""
+
+    raw: dict
+    host_monotonic: float | None = None  # host time.monotonic() at read, if set
+
+    # --- convenience accessors with engineering units -------------------
+    @property
+    def ctrl_exec_us_max(self) -> int:
+        return self.raw["ctrl_exec_us_max"]
+
+    @property
+    def ctrl_period_us_max(self) -> int:
+        return self.raw["ctrl_period_us_max"]
+
+    @property
+    def ctrl_period_us_min(self) -> int:
+        return self.raw["ctrl_period_us_min"]
+
+    @property
+    def main_loop_us_max(self) -> int:
+        return self.raw["main_loop_us_max"]
+
+    @property
+    def loop_iters(self) -> int:
+        return self.raw["loop_iters"]
+
+    @property
+    def zero_cross_count(self) -> int:
+        return self.raw["zero_cross_count"]
+
+    @property
+    def voltage(self) -> float:
+        """Battery voltage in volts (firmware reports centivolts)."""
+        return self.raw["voltage_cv"] / 100.0
+
+    @property
+    def current(self) -> float:
+        """Phase current in amps (firmware reports centiamps)."""
+        return self.raw["current_ca"] / 100.0
+
+    @property
+    def e_rpm(self) -> int:
+        """Electrical RPM (firmware reports eRPM/100)."""
+        return self.raw["e_rpm"] * 100
+
+    def mech_rpm(self, pole_pairs: int) -> float:
+        """Mechanical RPM derived from eRPM and motor pole pairs."""
+        return self.e_rpm / pole_pairs if pole_pairs else 0.0
+
+
+def decode(data: bytes, *, host_monotonic: float | None = None,
+           validate: bool = True) -> PerfSample:
+    """Decode ``data`` (>= :data:`SIZE` bytes) into a :class:`PerfSample`."""
+    if len(data) < SIZE:
+        raise PerfDecodeError(f"need {SIZE} bytes, got {len(data)}")
+    values = struct.unpack(_FORMAT, data[:SIZE])
+    raw = dict(zip(_NAMES, values))
+    if validate:
+        if raw["magic"] != MAGIC:
+            raise PerfDecodeError(
+                f"bad magic 0x{raw['magic']:08x} (expected 0x{MAGIC:08x}); "
+                "is the firmware built with HWCI_PERF=1?")
+        if raw["version"] != VERSION:
+            raise PerfDecodeError(
+                f"struct version {raw['version']} != host-expected {VERSION}; "
+                "rebuild or update hwci/hwci/perf.py")
+        if raw["size"] != SIZE:
+            raise PerfDecodeError(
+                f"struct size {raw['size']} != host-expected {SIZE}; "
+                "firmware/host layout drift - rebuild or update hwci/hwci/perf.py")
+    public = {k: raw[k] for k in _PUBLIC}
+    return PerfSample(raw=public, host_monotonic=host_monotonic)
+
+
+def encode(raw: dict) -> bytes:
+    """Inverse of :func:`decode` (used by the simulator and tests)."""
+    full = {name: 0 for name in _NAMES}
+    full.update({"magic": MAGIC, "version": VERSION, "size": SIZE})
+    full.update(raw)
+    return struct.pack(_FORMAT, *(full[name] for name in _NAMES))

--- a/hwci/hwci/perf_reader.py
+++ b/hwci/hwci/perf_reader.py
@@ -1,0 +1,84 @@
+"""Read and decode the firmware ``hwci_perf`` struct via a Debugger backend."""
+from __future__ import annotations
+
+import time
+import warnings
+
+from . import elf, perf
+from .debugger.base import Debugger, DebuggerError
+
+SYMBOL = "hwci_perf"
+STRUCT_TAG = "hwci_perf_s"
+
+
+class PerfReader:
+    """Locate ``hwci_perf`` once from the ELF, then sample it on demand.
+
+    On construction the symbol address is read from ``elf_path``. If the ELF
+    carries DWARF (AM32 builds with ``-g``), the on-target layout is cross-
+    checked against :data:`hwci.perf.FIELDS` so a firmware/host layout drift is
+    caught loudly instead of silently misread.
+    """
+
+    def __init__(self, dbg: Debugger, elf_path: str, *, check_layout: bool = True):
+        self.dbg = dbg
+        self.elf_path = elf_path
+        sym = elf.find_symbol(elf_path, SYMBOL)
+        self.address = sym.address
+        if sym.size and sym.size != perf.SIZE:
+            raise perf.PerfDecodeError(
+                f"hwci_perf ELF size {sym.size} != host {perf.SIZE}; "
+                "rebuild firmware or update hwci/hwci/perf.py")
+        if check_layout:
+            self._check_layout()
+
+    def _check_layout(self) -> None:
+        try:
+            members = {m.name: m for m in elf.struct_layout(self.elf_path, STRUCT_TAG)}
+        except elf.StructNotFoundError as e:
+            # DWARF exists but the struct DIE is gone (renamed tag, LTO/-g1
+            # stripping types): decoding would proceed on faith exactly when
+            # the cross-check matters most. Fail hard.
+            raise perf.PerfDecodeError(
+                f"cannot cross-check hwci_perf layout: {e}") from e
+        except elf.ElfError as e:
+            warnings.warn(f"hwci_perf layout cross-check skipped ({e}); "
+                          "relying on the canonical layout in hwci/hwci/perf.py")
+            return
+        off = 0
+        import struct as _struct
+        for name, code in perf.FIELDS:
+            size = _struct.calcsize(code)
+            if not name.startswith("_pad"):
+                m = members.get(name)
+                if m is None or m.offset != off or m.size != size:
+                    raise perf.PerfDecodeError(
+                        f"firmware/host layout mismatch at {name!r}: "
+                        f"ELF={m} canonical(off={off},size={size})")
+            off += size
+
+    def read(self) -> perf.PerfSample:
+        data = self.dbg.read_memory(self.address, perf.SIZE)
+        return perf.decode(data, host_monotonic=time.monotonic())
+
+    def reset_stats(self, *, verify: bool = True, timeout_s: float = 1.0) -> None:
+        """Ask the firmware to clear its sticky min/max accumulators.
+
+        With ``verify`` (the default) this polls until the firmware consumes
+        the command (it clears ``host_cmd`` within ~64 main-loop iterations).
+        A reset that silently never lands would let the previous run's maxima
+        pollute this run's gated metrics.
+        """
+        cmd_addr = self.address + perf.HOST_CMD_OFFSET
+        self.dbg.write_u32(cmd_addr, perf.CMD_RESET_STATS)
+        if not verify:
+            return
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            val = int.from_bytes(self.dbg.read_memory(cmd_addr, 4), "little")
+            if val == perf.CMD_NONE:
+                return
+            time.sleep(0.01)
+        raise DebuggerError(
+            "firmware did not acknowledge RESET_STATS within "
+            f"{timeout_s}s (is the target running HWCI_PERF firmware?)")

--- a/hwci/hwci/profiles/ci_smoke.yaml
+++ b/hwci/hwci/profiles/ci_smoke.yaml
@@ -1,0 +1,22 @@
+name: ci_smoke
+description: >
+  Fast, low-risk gate for CI. Arms, ramps to two modest steady points, returns
+  to idle. Validates the whole pipeline (build/flash/telemetry/perf) and catches
+  gross regressions in loop time, CPU load, and efficiency without stressing the
+  motor. ~25 s.
+sample_rate_hz: 100
+arm_settle_s: 2.0
+
+safety:
+  max_current_a: 35.0
+  max_thrust_n: 15.0
+  max_rpm: 30000
+
+segments:
+  - {label: idle,    throttle: 0.00, duration_s: 2.0}
+  - {label: ramp25,  throttle: 0.25, duration_s: 3.0, ramp: true}
+  - {label: hold25,  throttle: 0.25, duration_s: 5.0, steady: true}
+  - {label: ramp45,  throttle: 0.45, duration_s: 3.0, ramp: true}
+  - {label: hold45,  throttle: 0.45, duration_s: 5.0, steady: true}
+  - {label: rampdn,  throttle: 0.00, duration_s: 3.0, ramp: true}
+  - {label: stop,    throttle: 0.00, duration_s: 2.0}

--- a/hwci/hwci/profiles/demag_step_stress.yaml
+++ b/hwci/hwci/profiles/demag_step_stress.yaml
@@ -1,0 +1,27 @@
+name: demag_step_stress
+description: >
+  Aggressive instantaneous throttle steps (no ramp) between low and high to
+  provoke loss of sync / demagnetization. Detection is host-side: RPM/thrust
+  collapse while throttle is commanded high, ESC eRPM vs stand RPM divergence,
+  commutation-interval spikes, and firmware bemf-timeout flags. Run with caution
+  and conservative current/thrust cutoffs.
+sample_rate_hz: 200
+arm_settle_s: 2.0
+demag_commutation_spike: 3.0
+demag_rpm_drop_fraction: 0.25
+
+safety:
+  max_current_a: 45.0
+  max_thrust_n: 16.0
+  max_rpm: 32000
+
+segments:
+  - {label: idle,    throttle: 0.00, duration_s: 2.0}
+  - {label: pre,     throttle: 0.10, duration_s: 3.0, ramp: true}
+  - {label: step90a, throttle: 0.90, duration_s: 2.0}   # snap 10->90
+  - {label: drop10a, throttle: 0.10, duration_s: 2.0}   # snap 90->10
+  - {label: step95,  throttle: 0.95, duration_s: 2.0}
+  - {label: drop10b, throttle: 0.10, duration_s: 2.0}
+  - {label: step100, throttle: 1.00, duration_s: 2.0}
+  - {label: drop05,  throttle: 0.05, duration_s: 2.0}
+  - {label: rampdn,  throttle: 0.00, duration_s: 2.0, ramp: true}

--- a/hwci/hwci/profiles/efficiency_sweep.yaml
+++ b/hwci/hwci/profiles/efficiency_sweep.yaml
@@ -1,0 +1,40 @@
+name: efficiency_sweep
+description: >
+  Steady-state staircase from 10% to 100% throttle. Each step dwells long enough
+  to settle, and the tail of each is used to compute thrust, electrical power and
+  efficiency (g/W) plus loop time / CPU load at that operating point. This is the
+  primary efficiency + performance baseline.
+
+  Hold time is 6s. It was temporarily 10s while the ARK 4IN1 bench had severe
+  thrust-channel noise (sample CV up to 66%) that turned out to be prop-wake
+  impingement on the stand's mounting plate - the 5" disc sat entirely inside
+  the plate footprint blowing INTO it - not vibration to be averaged away.
+  With the prop reversed to exhaust into free air (thrust CV now 5.5-8.8%),
+  re-analysis of four 10s-hold captures truncated to 6s showed a 3s tail
+  changes gated points (>= 20W) by under +/-2% and leaves run-to-run
+  repeatability statistically unchanged (worst gated-point spread 9.8% vs
+  9.1%), so the extra 4s/point (~40s of motor+battery per sweep) bought
+  nothing. See Thresholds.efficiency_drop_pct in hwci/baseline.py for the
+  matching tolerance history.
+sample_rate_hz: 100
+arm_settle_s: 2.0
+steady_tail_fraction: 0.5
+
+safety:
+  max_current_a: 40.0
+  max_thrust_n: 16.0
+  max_rpm: 32000
+
+segments:
+  - {label: idle,   throttle: 0.00, duration_s: 2.0}
+  - {label: t10,    throttle: 0.10, duration_s: 6.0, ramp: true,  steady: true}
+  - {label: t20,    throttle: 0.20, duration_s: 6.0, steady: true}
+  - {label: t30,    throttle: 0.30, duration_s: 6.0, steady: true}
+  - {label: t40,    throttle: 0.40, duration_s: 6.0, steady: true}
+  - {label: t50,    throttle: 0.50, duration_s: 6.0, steady: true}
+  - {label: t60,    throttle: 0.60, duration_s: 6.0, steady: true}
+  - {label: t70,    throttle: 0.70, duration_s: 6.0, steady: true}
+  - {label: t80,    throttle: 0.80, duration_s: 6.0, steady: true}
+  - {label: t90,    throttle: 0.90, duration_s: 6.0, steady: true}
+  - {label: t100,   throttle: 1.00, duration_s: 6.0, steady: true}
+  - {label: rampdn, throttle: 0.00, duration_s: 4.0, ramp: true}

--- a/hwci/hwci/profiles/noprop_baseline.yaml
+++ b/hwci/hwci/profiles/noprop_baseline.yaml
@@ -1,0 +1,27 @@
+name: noprop_baseline
+description: >
+  No-prop performance baseline: steady staircase 10% to 50% throttle. Without a
+  prop there is no meaningful thrust/efficiency, but loop timing, CPU load,
+  commutation health, eRPM-vs-stand-RPM agreement, and no-load current per
+  operating point are all stable regression signals. Capped at 50% (a free
+  1800KV bell on 6S already turns ~22k RPM there); raise only with a load.
+  ~40 s.
+sample_rate_hz: 100
+arm_settle_s: 3.0
+steady_tail_fraction: 0.5
+
+safety:
+  max_current_a: 10.0    # no-load should stay under ~1.5 A; trips on desync/stall
+  max_thrust_n: 3.0      # ~0 expected without a prop; trips on sensor faults
+  max_rpm: 28000         # expected ~22.5k mech at 50%; hard stop above
+  max_motor_temp_c: 80.0 # IR probe on the motor (also gates KISS telem if wired)
+
+segments:
+  - {label: idle,   throttle: 0.00, duration_s: 2.0}
+  - {label: t10,    throttle: 0.10, duration_s: 6.0, ramp: true,  steady: true}
+  - {label: t20,    throttle: 0.20, duration_s: 6.0, steady: true}
+  - {label: t30,    throttle: 0.30, duration_s: 6.0, steady: true}
+  - {label: t40,    throttle: 0.40, duration_s: 6.0, steady: true}
+  - {label: t50,    throttle: 0.50, duration_s: 6.0, steady: true}
+  - {label: rampdn, throttle: 0.00, duration_s: 3.0, ramp: true}
+  - {label: stop,   throttle: 0.00, duration_s: 2.0}

--- a/hwci/hwci/profiles/noprop_smoke.yaml
+++ b/hwci/hwci/profiles/noprop_smoke.yaml
@@ -1,0 +1,23 @@
+name: noprop_smoke
+description: >
+  Bring-up validation with NO propeller installed: arms, holds two gentle
+  throttle points, returns to idle. Verifies throttle path, arming, spin-up,
+  and all data channels with minimal mechanical risk (no-load current is a
+  few amps). Thrust/efficiency numbers are meaningless without a prop - this
+  profile validates the pipeline, not the powertrain. ~20 s.
+sample_rate_hz: 100
+arm_settle_s: 3.0
+
+safety:
+  max_current_a: 8.0     # no-load current should stay well under this
+  max_thrust_n: 2.0      # ~0 expected without a prop; trips on sensor faults
+  max_rpm: 25000         # 1800KV @ 6S free-runs ~45k at 100%; stay low
+
+segments:
+  - {label: idle,    throttle: 0.00, duration_s: 2.0}
+  - {label: ramp10,  throttle: 0.10, duration_s: 2.0, ramp: true}
+  - {label: hold10,  throttle: 0.10, duration_s: 4.0, steady: true}
+  - {label: ramp20,  throttle: 0.20, duration_s: 2.0, ramp: true}
+  - {label: hold20,  throttle: 0.20, duration_s: 4.0, steady: true}
+  - {label: rampdn,  throttle: 0.00, duration_s: 2.0, ramp: true}
+  - {label: stop,    throttle: 0.00, duration_s: 2.0}

--- a/hwci/hwci/report.py
+++ b/hwci/hwci/report.py
@@ -1,0 +1,113 @@
+"""Render run metrics + regression comparison to Markdown (and optional plots)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _fmt(v) -> str:
+    if v is None:
+        return "-"
+    if isinstance(v, float):
+        return f"{v:.3f}" if abs(v) < 1000 else f"{v:.0f}"
+    return str(v)
+
+
+def render_markdown(metrics: dict, comparison: dict | None = None,
+                    meta: dict | None = None) -> str:
+    out: list[str] = []
+    out.append("# AM32 Hardware-CI Report\n")
+    if meta:
+        out.append("## Run\n")
+        for k in ("target", "profile", "mode", "git_sha", "firmware_version",
+                  "motor", "prop", "pole_pairs", "timestamp", "aborted",
+                  "perf_read_errors"):
+            if k in meta and meta[k] is not None:
+                out.append(f"- **{k}**: {meta[k]}")
+        out.append("")
+
+    s = metrics["summary"]
+    if comparison is not None:
+        verdict = "✅ PASS" if comparison["passed"] else "❌ FAIL"
+        out.append(f"## Verdict: {verdict}\n")
+
+    out.append("## Summary\n")
+    out.append("| metric | value |")
+    out.append("|---|---|")
+    for k, v in s.items():
+        out.append(f"| {k} | {_fmt(v)} |")
+    out.append("")
+
+    pts = metrics.get("steady_points", [])
+    if pts:
+        out.append("## Steady-state operating points\n")
+        cols = ["segment", "throttle", "rpm", "thrust_gf", "current_a",
+                "voltage_v", "elec_power_w", "eff_gf_per_w",
+                "ctrl_exec_us_max", "cpu_load_pct"]
+        out.append("| " + " | ".join(cols) + " |")
+        out.append("|" + "---|" * len(cols))
+        for p in pts:
+            out.append("| " + " | ".join(_fmt(p.get(c)) for c in cols) + " |")
+        out.append("")
+
+    d = metrics.get("demag", {})
+    out.append("## Demag / desync\n")
+    out.append(f"- events: **{d.get('event_count', 0)}**")
+    out.append(f"- bemf-timeout samples: {d.get('bemf_timeout_samples', 0)}")
+    out.append(f"- commutation-spike samples: {d.get('comm_spike_samples', 0)}")
+    out.append(f"- ESC-eRPM vs stand-RPM mismatch samples: "
+               f"{d.get('esc_rpm_mismatch_samples', 0)}")
+    out.append("")
+
+    if comparison is not None:
+        out.append("## Regression checks (vs baseline)\n")
+        out.append("| check | baseline | current | pass | rule |")
+        out.append("|---|---|---|---|---|")
+        for c in comparison["checks"]:
+            mark = "✅" if c["pass"] else "❌"
+            out.append(f"| {c['name']} | {_fmt(c['baseline'])} | "
+                       f"{_fmt(c['current'])} | {mark} | {c['note']} |")
+        out.append("")
+
+    return "\n".join(out)
+
+
+def write_report(run_dir: str | Path, metrics: dict,
+                 comparison: dict | None = None, meta: dict | None = None,
+                 plots: bool = True) -> Path:
+    run_dir = Path(run_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    md = render_markdown(metrics, comparison, meta)
+    report_path = run_dir / "report.md"
+    report_path.write_text(md)
+    if plots:
+        try:
+            _write_plots(run_dir, metrics)
+        except Exception:
+            pass  # plotting is best-effort / optional
+    return report_path
+
+
+def _write_plots(run_dir: Path, metrics: dict) -> None:
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    pts = metrics.get("steady_points", [])
+    if not pts:
+        return
+    thr = [p["throttle"] * 100 for p in pts]
+
+    fig, axes = plt.subplots(2, 2, figsize=(10, 7))
+    axes[0, 0].plot(thr, [p["thrust_gf"] for p in pts], "o-")
+    axes[0, 0].set(title="Thrust", xlabel="throttle %", ylabel="gf")
+    axes[0, 1].plot(thr, [p["eff_gf_per_w"] for p in pts], "o-", color="green")
+    axes[0, 1].set(title="Efficiency", xlabel="throttle %", ylabel="g/W")
+    axes[1, 0].plot(thr, [p["cpu_load_pct"] for p in pts], "o-", color="red")
+    axes[1, 0].set(title="CPU load", xlabel="throttle %", ylabel="%")
+    axes[1, 1].plot(thr, [p["ctrl_exec_us_max"] for p in pts], "o-", color="purple")
+    axes[1, 1].axhline(50, ls="--", color="gray", label="20kHz budget")
+    axes[1, 1].set(title="Control-loop exec", xlabel="throttle %", ylabel="us")
+    axes[1, 1].legend()
+    fig.tight_layout()
+    fig.savefig(run_dir / "summary.png", dpi=110)
+    plt.close(fig)

--- a/hwci/hwci/runner.py
+++ b/hwci/hwci/runner.py
@@ -1,0 +1,522 @@
+"""Test runner: execute a profile, sampling stand + ESC telemetry + perf struct.
+
+The runner is source-agnostic: it drives a :class:`ThrottleSource`, reads a
+:class:`ThrustStand`, and calls two callables for the perf struct and ESC
+telemetry. :func:`build_sim_sources` wires all of these to one shared
+:class:`~hwci.sim.RigSimulator` for offline runs; :func:`build_live_sources`
+wires them to OpenOCD + serial + the gRPC stand on the rig.
+
+Safety: the profile's :class:`~hwci.flightstand.base.SafetyLimits` are enforced
+HERE, on every sample, against both the stand reading and the ESC telemetry.
+Backends may additionally enforce them, but the runner check is the one that
+exists on every rig (the vendor gRPC API has no mapped set-limit RPC yet).
+
+Pre-flight: :func:`check_battery` gates a hardware run on pack voltage BEFORE
+the throttle is ever armed (see :func:`build_live_sources`). It is opt-in
+(``--battery-cells``) and separate from the per-sample ``SafetyLimits`` above -
+a low-but-not-crashing pack should never even start a test, both to protect
+the pack and because a sagging supply quietly corrupts efficiency data.
+:func:`tare_for_run` then zeroes the load cells on every hardware run that has
+a stand (default-on, ``--no-tare`` to skip) - with the ESC signal already up
+at zero throttle, because AM32 beeps the motor whenever it has no input.
+"""
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from . import perf
+from .config import Profile, RigConfig
+from .esc_telem.kiss import KissFrame, KissStream, parse_frame
+from .flightstand.base import SafetyLimits, StandSafetyTripped, StandSample, ThrustStand
+from .metrics import tail_start_index
+from .model import RunResult, make_row
+from .perf import PerfSample
+from .perf_reader import PerfReader
+from .throttle.base import ThrottleSource
+
+PerfSourceFn = Callable[[], Optional[PerfSample]]
+TelemSourceFn = Callable[[], Optional[KissFrame]]
+
+
+@dataclass
+class Sources:
+    throttle: ThrottleSource
+    stand: Optional[ThrustStand]
+    perf_source: PerfSourceFn
+    telem_source: TelemSourceFn
+    perf_reader: Optional[PerfReader] = None
+    closers: list = field(default_factory=list)
+
+    def close(self) -> None:
+        for c in reversed(self.closers):
+            try:
+                c()
+            except Exception:
+                pass
+
+
+# Ticks of margin between issuing a mid-segment perf-stats reset and the
+# metrics tail window's first sample - see the call site in run_profile for
+# why this must be a margin, not an exact boundary match.
+RESET_MARGIN_TICKS = 20
+
+
+def _tail_reset_tick(n: int, steady_tail_fraction: float) -> int:
+    """Tick within a steady segment to reset perf stats at, strictly before
+    the metrics tail window - computed from the SAME tail_start_index() the
+    metrics module uses, so the two can never disagree by a rounding tick."""
+    return max(0, tail_start_index(n, steady_tail_fraction) - RESET_MARGIN_TICKS)
+
+
+def _segment_throttle(seg, tick_in_seg: int, n_ticks: int, prev: float) -> float:
+    if not seg.ramp or n_ticks <= 1:
+        return seg.throttle
+    frac = tick_in_seg / (n_ticks - 1)
+    return prev + (seg.throttle - prev) * min(1.0, frac)
+
+
+def enforce_safety(limits: SafetyLimits, stand: StandSample | None,
+                   telem: KissFrame | None) -> None:
+    """Host-side safety check against every channel that produced data."""
+    if stand is not None:
+        limits.check(thrust_n=stand.thrust_n, current_a=stand.current_a,
+                     rpm=stand.rpm, voltage_v=stand.voltage_v,
+                     temp_c=stand.motor_temp_c)
+    if telem is not None:
+        limits.check(current_a=telem.current_a, temp_c=telem.temperature_c)
+
+
+# Default per-cell low-voltage threshold for check_battery(). Matches AM32
+# firmware's own default (Src/main.c: `low_cell_volt_cutoff = 330` -> 3.30
+# V/cell), so the harness refuses to start a test at roughly the same pack
+# voltage the ESC would eventually cut power at mid-run anyway.
+DEFAULT_MIN_CELL_VOLTAGE = 3.3
+
+
+class BatteryTooLowError(RuntimeError):
+    """Raised before a run is armed: the pack is already at/below the
+    minimum for its declared cell count, or its voltage can't be verified at
+    all. Fails closed - a test must not start on a battery this low, both to
+    avoid over-discharging it and because a sagging supply quietly corrupts
+    efficiency data."""
+
+
+def _live_voltage(stand: ThrustStand | None,
+                  perf_source: PerfSourceFn) -> float | None:
+    """Best pack-voltage reading available before the throttle is armed: the
+    stand's HV bus channel if one is wired, else the ESC's own ADC via the
+    perf struct (already alive by the time build_live_sources calls this -
+    it runs after _ensure_app_alive). None if neither is available/readable."""
+    if stand is not None:
+        return stand.read_sample().voltage_v
+    pf = _safe(perf_source)
+    return pf.voltage if pf is not None else None
+
+
+def check_battery(voltage_v: float | None, battery_cells: int,
+                  min_cell_voltage: float = DEFAULT_MIN_CELL_VOLTAGE) -> None:
+    """Refuse to proceed if the pack is at/below a safe minimum for its
+    declared cell count. Only called when the caller passed
+    ``--battery-cells`` - this check is opt-in, not a default gate."""
+    minimum = battery_cells * min_cell_voltage
+    if voltage_v is None:
+        raise BatteryTooLowError(
+            "cannot verify battery voltage before starting (no stand or "
+            "perf voltage channel available on this rig) - wire a voltage "
+            "channel or drop --battery-cells to skip this check")
+    if voltage_v < minimum:
+        raise BatteryTooLowError(
+            f"battery {voltage_v:.2f} V < minimum {minimum:.2f} V for a "
+            f"{battery_cells}S pack at {min_cell_voltage:.2f} V/cell - "
+            "charge or swap the pack before running a test")
+
+
+# Pre-run tare choreography. AM32 beeps the motor whenever it sees NO input
+# signal (the disconnect beacon) and again as it arms - each beep is a real
+# torque pulse through the mount, so a tare taken on a signal-less ESC bakes
+# that twitching into the load-cell zero. Bring the signal up at zero
+# throttle FIRST (the beacon stops), wait out the arm tune, and only then
+# zero the load cells on a mechanically quiet rig.
+ARM_TUNE_SETTLE_S = 2.0  # arm tune keeps shaking the motor after arm() returns
+TARE_SETTLE_S = 1.5      # post-tare readings stay noisy for ~1-2 s (bench)
+
+
+def tare_for_run(stand: ThrustStand, throttle: ThrottleSource, *,
+                 settle: Callable[[float], None] = time.sleep) -> float | None:
+    """Zero the load cells with the ESC held quiet at zero throttle (see the
+    choreography note above). Returns the post-tare thrust residual in gf so
+    the caller can surface it, or None if it can't be read - the residual
+    read is best-effort, the tare itself is not."""
+    throttle.arm()             # signal present at zero: beacon stops, ESC arms
+    settle(ARM_TUNE_SETTLE_S)
+    stand.tare()
+    settle(TARE_SETTLE_S)
+    try:
+        return stand.read_sample().thrust_n * 1000.0 / 9.80665
+    except Exception:
+        return None
+
+
+class _CachedPoller:
+    """Background thread that keeps the most recent value of a slow source.
+
+    An SWD struct read through ST-Link costs milliseconds; done inline it
+    would consume the whole tick budget at 100-200 Hz and add jitter to every
+    sample. Read errors are counted, never swallowed silently.
+    """
+
+    def __init__(self, fn, *, interval_s: float = 0.002,
+                 max_age_s: float = 1.0, name: str = "poller"):
+        self._fn = fn
+        self._interval = interval_s
+        self._max_age = max_age_s
+        self._latest = None
+        self._latest_at = float("-inf")
+        self._errors = 0
+        self._last_error: Exception | None = None
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._loop, daemon=True, name=name)
+        self._thread.start()
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                value = self._fn()
+            except Exception as e:
+                self._errors += 1
+                self._last_error = e
+            else:
+                self._latest = value
+                self._latest_at = time.monotonic()
+            self._stop.wait(self._interval)
+
+    def latest(self):
+        """Most recent value, or None once the source has been dead for
+        max_age_s (a stale sample repeated forever would defeat the
+        channel-coverage gate downstream)."""
+        if time.monotonic() - self._latest_at > self._max_age:
+            return None
+        return self._latest
+
+    @property
+    def errors(self) -> int:
+        return self._errors
+
+    @property
+    def last_error(self) -> Exception | None:
+        return self._last_error
+
+    def close(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=1.0)
+
+
+def run_profile(profile: Profile, sources: Sources, *,
+                realtime: bool = True, meta: dict | None = None) -> RunResult:
+    period = 1.0 / profile.sample_rate_hz
+    rows: list[dict] = []
+    aborted: str | None = None
+
+    sources.throttle.arm()
+    if sources.perf_reader is not None:
+        sources.perf_reader.reset_stats()  # measure worst-case for THIS run
+
+    # Slow live sources move to a caching poller thread so the tick loop stays
+    # deterministic. The sim path stays inline (cheap and reproducible).
+    perf_poller: _CachedPoller | None = None
+    perf_get: Callable[[], PerfSample | None]
+    telem_errors = 0
+    if realtime and sources.perf_reader is not None:
+        perf_poller = _CachedPoller(sources.perf_source, name="perf-poller")
+        perf_get = perf_poller.latest
+    else:
+        def perf_get():
+            return _safe(sources.perf_source)
+
+    start = time.monotonic()
+    tick = 0
+    prev_throttle = 0.0
+    try:
+        for seg in profile.segments:
+            n = max(1, round(seg.duration_s * profile.sample_rate_hz))
+            # Reset the firmware's sticky min/max accumulators BEFORE a
+            # steady segment's measurement tail begins (with a margin - see
+            # _tail_reset_tick), so the tail's worst case reflects THIS
+            # operating point - not the spin-up transient of the run so far
+            # (~700-950 us on the bench, varying 30%+ run-to-run, which would
+            # drown steady loop-time regressions).
+            #
+            # The reset must land strictly BEFORE the tail's first sample,
+            # not AT it: reset_stats() clears the firmware register over an
+            # SWD round trip, and in realtime mode perf_get() reads an
+            # independent background poller's CACHED value (_CachedPoller,
+            # ~2ms interval) - so the tick that ISSUES the reset can still
+            # observe the pre-reset cached sample. Observed on the bench: an
+            # 877us arming-tune-transient value latched at t10's first tick
+            # persisted for the segment's first 5s and was still visible in
+            # the very sample the reset was issued on, making the "steady"
+            # max equal the raw run max. A margin many times the poller
+            # interval (and typical SWD round trip) makes this exclusion
+            # instead of a race.
+            tail_reset_tick = (_tail_reset_tick(n, profile.steady_tail_fraction)
+                               if seg.steady and sources.perf_reader is not None
+                               else None)
+            for i in range(n):
+                t_sched = tick * period
+                if realtime:
+                    target = start + t_sched
+                    delay = target - time.monotonic()
+                    if delay > 0:
+                        time.sleep(delay)
+                if tail_reset_tick is not None and i == tail_reset_tick:
+                    try:
+                        sources.perf_reader.reset_stats(verify=False)
+                    except Exception:
+                        pass  # a missed reset degrades one segment, not the run
+                throttle = _segment_throttle(seg, i, n, prev_throttle)
+                sources.throttle.set(throttle)
+                stand = sources.stand.read_sample() if sources.stand is not None else None
+                pf = perf_get()
+                tm = _safe(sources.telem_source)
+                enforce_safety(profile.safety, stand, tm)
+                # Record the ACTUAL sample time: after a host stall the
+                # schedule time would lie about how much wall clock the
+                # sample covers (and corrupt counter-rate math downstream).
+                t = (time.monotonic() - start) if realtime else t_sched
+                rows.append(make_row(t, seg.label, throttle, stand, tm, pf))
+                tick += 1
+            prev_throttle = seg.throttle
+    except StandSafetyTripped as e:
+        aborted = f"safety: {e}"
+    finally:
+        try:
+            sources.throttle.disarm()
+        finally:
+            if perf_poller is not None:
+                perf_poller.close()
+
+    full_meta = {
+        "profile": profile.name,
+        "sample_rate_hz": profile.sample_rate_hz,
+        "n_samples": len(rows),
+        "aborted": aborted,
+        "wall_time_s": round(time.monotonic() - start, 3),
+        "perf_read_errors": perf_poller.errors if perf_poller is not None else 0,
+    }
+    if perf_poller is not None and perf_poller.last_error is not None:
+        full_meta["perf_last_error"] = repr(perf_poller.last_error)
+    if meta:
+        full_meta.update(meta)
+    return RunResult(meta=full_meta, rows=rows)
+
+
+def _safe(fn):
+    try:
+        return fn()
+    except Exception:
+        return None
+
+
+# --------------------------------------------------------------------------
+# Source builders
+# --------------------------------------------------------------------------
+def build_sim_sources(rig: RigConfig, profile: Profile, *,
+                      demag_prone: bool = True) -> Sources:
+    """All three channels fed by one RigSimulator (deterministic, no hardware)."""
+    from .flightstand.simulator import SimulatedStand
+    from .sim import MotorParams, RigSimulator
+    from .throttle.flightstand_src import FlightStandThrottle
+
+    period = 1.0 / profile.sample_rate_hz
+    sim = RigSimulator(params=MotorParams(pole_pairs=rig.pole_pairs,
+                                          demag_prone=demag_prone))
+    stand = SimulatedStand(sim, fixed_dt=period).open()
+    stand.set_safety_limits(profile.safety)
+    throttle = FlightStandThrottle(stand, arm_settle_s=0.0)
+    return Sources(
+        throttle=throttle,
+        stand=stand,
+        perf_source=lambda: perf.decode(sim.perf_bytes()),
+        telem_source=lambda: parse_frame(sim.kiss_bytes()),
+        closers=[stand.close],
+    )
+
+
+def _ensure_app_alive(dbg, perf_reader: PerfReader,
+                      throttle: ThrottleSource) -> None:
+    """Get the ESC out of the AM32 bootloader and into the app.
+
+    The bootloader only jumps to the app when the throttle signal line idles
+    LOW at boot. A floating line reads high, and an ACTIVE DShot output keeps
+    the line high 40-75% of each frame - either way the ESC parks in the
+    bootloader after a flash/power-cycle and the run would produce no perf
+    data and never arm. Detected via the hwci_perf magic: quiesce the
+    throttle source (signal dropped, line driven low), reset, and wait for
+    the app to publish the magic. The throttle is re-activated later by
+    ``arm()``.
+    """
+    from .perf import PerfDecodeError
+
+    def app_alive() -> bool:
+        # Only a decode failure means "bootloader/no instrumentation";
+        # a debugger error is a different fault and must propagate.
+        try:
+            perf_reader.read()
+            return True
+        except PerfDecodeError:
+            return False
+
+    if app_alive():
+        return
+    for _attempt in range(2):
+        throttle.quiesce()  # drop the signal so the line is driven low
+        time.sleep(0.2)     # let the output state settle
+        dbg.reset_run()
+        deadline = time.monotonic() + 8.0  # boot + arming tune
+        while time.monotonic() < deadline:
+            time.sleep(0.25)
+            if app_alive():
+                return
+    raise RuntimeError(
+        "ESC app never came up (hwci_perf magic invalid after reset). "
+        "Either the flashed firmware was built without HWCI_PERF=1, or the "
+        "ESC is stuck in the AM32 bootloader because the throttle signal "
+        "line idles high at reset (check the stand's ESC output wiring and "
+        "that the throttle backend can drive it).")
+
+
+class _SerialTelemetry:
+    """Background thread holding the most recent KISS frame from a serial port."""
+
+    def __init__(self, port: str, baud: int):
+        import serial
+        self._ser = serial.Serial(port, baud, timeout=0.05)
+        self._stream = KissStream()
+        self._latest: KissFrame | None = None
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            chunk = self._ser.read(64)
+            if chunk:
+                for frame in self._stream.feed(chunk):
+                    self._latest = frame
+
+    def latest(self) -> KissFrame | None:
+        return self._latest
+
+    def close(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=1.0)
+        self._ser.close()
+
+
+def build_live_sources(rig: RigConfig, profile: Profile, *,
+                       battery_cells: int | None = None,
+                       min_cell_voltage: float = DEFAULT_MIN_CELL_VOLTAGE,
+                       tare: bool = True) -> Sources:
+    """Wire OpenOCD + serial telemetry + gRPC/external throttle on the rig.
+
+    Backend values dispatch STRICTLY: an unknown value raises instead of
+    falling back to a simulator (fabricated data gating a hardware run is the
+    one unrecoverable failure mode). ``none`` disables a channel explicitly.
+
+    If ``battery_cells`` is given, pack voltage is checked against
+    ``battery_cells * min_cell_voltage`` before the throttle is armed (see
+    :func:`check_battery`) - the run refuses to start on a pack that's
+    already too low.
+
+    Unless ``tare`` is False, a stand's load cells are zeroed as the last
+    pre-flight step via :func:`tare_for_run` (ESC signal up at zero throttle
+    first, so AM32's beacon/arm beeps don't shake the cells mid-tare). A tare
+    that fails aborts the run: after any mechanical change an untared cell
+    reads a bogus thrust offset, which is worse than no run.
+    """
+    closers: list = []
+
+    # --- thrust stand ---
+    stand: ThrustStand | None
+    if rig.stand_backend == "grpc":
+        from .flightstand.grpc_client import FlightStandGrpc, SignalMap
+        sig = SignalMap(**rig.stand_signals) if rig.stand_signals else SignalMap()
+        stand = FlightStandGrpc(rig.stand_host, rig.stand_port, signals=sig).open()
+        stand.set_safety_limits(profile.safety)
+        closers.append(stand.close)
+    elif rig.stand_backend == "none":
+        stand = None
+    else:
+        raise ValueError(
+            f"stand_backend {rig.stand_backend!r} is not a live backend "
+            "(expected 'grpc' or 'none')")
+
+    # --- throttle source ---
+    if rig.throttle_backend == "external":
+        from .throttle.external import ExternalSerialThrottle
+        throttle = ExternalSerialThrottle(rig.throttle_port, rig.throttle_baud)
+    elif rig.throttle_backend == "flightstand":
+        if stand is None:
+            raise ValueError(
+                "throttle_backend 'flightstand' needs stand_backend 'grpc'")
+        from .throttle.flightstand_src import FlightStandThrottle
+        throttle = FlightStandThrottle(stand, arm_settle_s=profile.arm_settle_s)
+    else:
+        raise ValueError(
+            f"throttle_backend {rig.throttle_backend!r} is not a live backend "
+            "(expected 'flightstand' or 'external')")
+    closers.append(throttle.close)
+
+    # --- perf struct via debugger ---
+    perf_reader = None
+    perf_source: PerfSourceFn = lambda: None
+    if rig.debugger_backend == "openocd":
+        from .debugger.openocd import OpenOcdDebugger
+        elf = rig.resolved_elf()
+        if elf is None:
+            raise FileNotFoundError(
+                f"no ELF for target {rig.target} in {rig.resolved_obj_dir()}; "
+                "build with HWCI_PERF=1 first")
+        dbg = OpenOcdDebugger(rig.openocd_configs, openocd_bin=rig.openocd_bin,
+                              search_dirs=rig.openocd_search_dirs).open()
+        perf_reader = PerfReader(dbg, str(elf))
+        perf_source = perf_reader.read
+        closers.append(dbg.close)
+    elif rig.debugger_backend != "none":
+        raise ValueError(
+            f"debugger_backend {rig.debugger_backend!r} is not a live backend "
+            "(expected 'openocd' or 'none')")
+
+    # --- ESC telemetry ---
+    telem_source: TelemSourceFn = lambda: None
+    if rig.telem_backend == "serial":
+        telem = _SerialTelemetry(rig.telem_port, rig.telem_baud)
+        telem_source = telem.latest
+        closers.append(telem.close)
+    elif rig.telem_backend != "none":
+        raise ValueError(
+            f"telem_backend {rig.telem_backend!r} is not a live backend "
+            "(expected 'serial' or 'none')")
+
+    sources = Sources(throttle=throttle, stand=stand, perf_source=perf_source,
+                      telem_source=telem_source, perf_reader=perf_reader,
+                      closers=closers)
+    try:
+        if perf_reader is not None:
+            _ensure_app_alive(dbg, perf_reader, throttle)
+        if battery_cells is not None:
+            check_battery(_live_voltage(stand, perf_source), battery_cells,
+                         min_cell_voltage)
+        if tare and stand is not None:
+            residual_gf = tare_for_run(stand, throttle)
+            if residual_gf is not None:
+                print(f"tared load cells (ESC armed quiet at zero): "
+                      f"residual {residual_gf:+.1f} gf", file=sys.stderr)
+    except Exception:
+        sources.close()
+        raise
+    return sources

--- a/hwci/hwci/sim.py
+++ b/hwci/hwci/sim.py
@@ -1,0 +1,210 @@
+"""Offline rig simulator.
+
+Produces self-consistent data across all three measurement channels from a
+single throttle command:
+
+  * thrust-stand sample (thrust, torque, RPM, V, A)
+  * ESC KISS telemetry frame (temp, V, A, consumption, eRPM)
+  * firmware ``hwci_perf`` struct bytes (loop times, counters, snapshot)
+
+It is a phenomenological model, not a high-fidelity one - enough to exercise the
+whole harness (metrics, baseline, report, runner) without hardware and to make
+demag-detection logic testable by injecting desync events on aggressive steps.
+"""
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass, field
+
+from . import perf
+from .esc_telem.kiss import encode_frame
+from .flightstand.base import StandSample
+
+
+@dataclass
+class MotorParams:
+    pole_pairs: int = 7
+    kv: float = 1900.0                 # rpm / V
+    batt_voltage: float = 16.8         # 4S nominal
+    internal_resistance: float = 0.02  # ohm (battery + wiring)
+    throttle_rpm_fraction: float = 0.85
+    ct: float = 1.6e-8                 # thrust [N] = ct * rpm^2
+    cq: float = 1.43e-10               # torque [Nm] = cq * rpm^2
+    motor_efficiency: float = 0.82
+    idle_power_w: float = 3.0
+    tau_s: float = 0.08               # spool-up time constant
+    ambient_temp_c: float = 25.0
+    # demag behaviour
+    demag_prone: bool = False
+    demag_step_threshold: float = 0.35   # throttle jump that can desync
+    demag_current_a: float = 18.0        # current above which a jump desyncs
+    desync_ticks: int = 8
+
+
+@dataclass
+class RigSimulator:
+    params: MotorParams = field(default_factory=MotorParams)
+    seed: int = 1234
+    noise: float = 0.01  # fractional measurement noise
+
+    def __post_init__(self):
+        self._rng = random.Random(self.seed)
+        self.rpm = 0.0
+        self.throttle = 0.0
+        self._prev_cmd = 0.0
+        self.consumption_mah = 0.0
+        self.temp_c = self.params.ambient_temp_c
+        self.loop_iters = 0
+        self.zero_cross_count = 0
+        self.update_count = 0
+        self.desync_remaining = 0
+        self.desync_count = 0
+        self._ctrl_exec_max = 0
+        self._commutation_max = 0
+
+    # --- model -------------------------------------------------------
+    def _rpm_max(self) -> float:
+        p = self.params
+        return p.kv * p.batt_voltage * p.throttle_rpm_fraction
+
+    def step(self, dt: float, throttle: float) -> None:
+        p = self.params
+        throttle = max(0.0, min(1.0, throttle))
+        cmd_jump = throttle - self._prev_cmd
+
+        # Detect a demag/desync trigger: a big, fast throttle increase into a
+        # high-current regime on a demag-prone motor.
+        target_rpm = throttle * self._rpm_max()
+        provisional_current = self._current_for_rpm(target_rpm, p.batt_voltage)
+        if (p.demag_prone and self.desync_remaining == 0
+                and cmd_jump > p.demag_step_threshold
+                and provisional_current > p.demag_current_a):
+            self.desync_remaining = p.desync_ticks
+            self.desync_count += 1
+
+        if self.desync_remaining > 0:
+            # Loss of sync: rotor falls back, electrical drive flails.
+            self.rpm *= 0.7
+            self.desync_remaining -= 1
+        else:
+            alpha = 1.0 - math.exp(-dt / max(p.tau_s, 1e-3))
+            self.rpm += (target_rpm - self.rpm) * alpha
+
+        self.rpm = max(self.rpm, 0.0)
+        self.throttle = throttle
+        self._prev_cmd = throttle
+
+        # bookkeeping that the perf struct exposes
+        erev_per_s = self.rpm * p.pole_pairs / 60.0
+        self.zero_cross_count += int(erev_per_s * 6.0 * dt)
+        # idle loop iterations: ~120 kHz when idle, dropping with motor load
+        idle_hz = 120000.0 * (1.0 - 0.25 * throttle)
+        self.loop_iters += int(idle_hz * dt)
+        self.update_count += int(idle_hz * dt)
+        # current draw heats the ESC slowly
+        cur = self.current
+        self.temp_c += (p.ambient_temp_c + 0.9 * cur - self.temp_c) * min(1.0, dt / 5.0)
+        self.consumption_mah += cur * dt / 3.6  # A*s -> mAh
+
+    def _current_for_rpm(self, rpm: float, v: float) -> float:
+        p = self.params
+        torque = p.cq * rpm * rpm
+        omega = rpm * 2.0 * math.pi / 60.0
+        mech = torque * omega
+        elec = mech / p.motor_efficiency + p.idle_power_w
+        return elec / max(v, 1.0)
+
+    # --- derived measurements ---------------------------------------
+    @property
+    def thrust_n(self) -> float:
+        return self.params.ct * self.rpm * self.rpm
+
+    @property
+    def torque_nm(self) -> float:
+        return self.params.cq * self.rpm * self.rpm
+
+    @property
+    def current(self) -> float:
+        p = self.params
+        cur = self._current_for_rpm(self.rpm, p.batt_voltage)
+        if self.desync_remaining > 0:
+            cur *= 1.6  # current spike during desync
+        return cur
+
+    @property
+    def voltage(self) -> float:
+        p = self.params
+        return p.batt_voltage - self.current * p.internal_resistance
+
+    @property
+    def e_rpm(self) -> float:
+        return self.rpm * self.params.pole_pairs
+
+    def _n(self, value: float) -> float:
+        """Apply multiplicative measurement noise."""
+        if self.noise <= 0:
+            return value
+        return value * (1.0 + self._rng.uniform(-self.noise, self.noise))
+
+    # --- channel outputs --------------------------------------------
+    def stand_sample(self, t: float) -> StandSample:
+        return StandSample(
+            t=t,
+            throttle=self.throttle,
+            thrust_n=self._n(self.thrust_n),
+            torque_nm=self._n(self.torque_nm),
+            rpm=self._n(self.rpm),
+            voltage_v=self._n(self.voltage),
+            current_a=self._n(self.current),
+        )
+
+    def kiss_bytes(self) -> bytes:
+        return encode_frame(
+            temperature_c=int(self.temp_c),
+            voltage_cv=int(self.voltage * 100),
+            current_ca=int(self.current * 100),
+            consumption_mah=int(self.consumption_mah),
+            erpm100=int(self.e_rpm / 100),
+        )
+
+    def perf_bytes(self) -> bytes:
+        p = self.params
+        erev_per_s = self.e_rpm / 60.0
+        commutations_per_s = erev_per_s * 6.0
+        if commutations_per_s > 1.0:
+            comm_interval = int((1.0 / commutations_per_s) / 0.5e-6)
+        else:
+            comm_interval = 0xFFFF
+        if self.desync_remaining > 0:
+            comm_interval = min(0xFFFFFF, comm_interval * 8)
+        self._commutation_max = max(self._commutation_max, comm_interval)
+        ctrl_exec = 16 + int(self._rng.uniform(0, 6))
+        self._ctrl_exec_max = max(self._ctrl_exec_max, ctrl_exec)
+        return perf.encode({
+            "ctrl_exec_us_last": ctrl_exec,
+            "ctrl_exec_us_max": self._ctrl_exec_max,
+            "ctrl_period_us_last": 50,
+            "ctrl_period_us_max": 52,
+            "ctrl_period_us_min": 48,
+            "main_loop_us_last": 5,
+            "main_loop_us_max": 9,
+            "input": int(self.throttle * 2000),
+            "duty_cycle": int(self.throttle * 2000),
+            "e_rpm": int(self.e_rpm / 100) & 0xFFFF,
+            "voltage_cv": int(self.voltage * 100) & 0xFFFF,
+            "current_ca": int(self.current * 100) & 0x7FFF,
+            "temperature_c": int(self.temp_c),
+            "bemf_timeout_state": 1 if self.desync_remaining > 0 else 0,
+            "armed": 1,
+            "running": 1 if self.rpm > 100 else 0,
+            "loop_iters": self.loop_iters & 0xFFFFFFFF,
+            # firmware clamps zero_crosses at 10000 (and resets it on
+            # desync/stop) - mirror the saturation so host logic tested
+            # against the sim cannot assume a monotonic counter
+            "zero_cross_count": min(self.zero_cross_count, 10000),
+            "commutation_interval": comm_interval,
+            "commutation_interval_max": self._commutation_max,
+            "update_count": self.update_count & 0xFFFFFFFF,
+            "host_cmd": 0,
+        })

--- a/hwci/hwci/throttle/__init__.py
+++ b/hwci/hwci/throttle/__init__.py
@@ -1,0 +1,4 @@
+"""Throttle-source backends (what physically commands the ESC signal wire)."""
+from .base import ThrottleSource  # noqa: F401
+from .flightstand_src import FlightStandThrottle  # noqa: F401
+from .external import ExternalSerialThrottle  # noqa: F401

--- a/hwci/hwci/throttle/base.py
+++ b/hwci/hwci/throttle/base.py
@@ -1,0 +1,48 @@
+"""Throttle-source abstraction.
+
+The throttle source is whatever generates the ESC signal during a test. Two
+backends are provided:
+
+* :class:`~hwci.throttle.flightstand_src.FlightStandThrottle` - the Flight Stand
+  drives its own ESC output; simplest and perfectly synchronized with logging.
+* :class:`~hwci.throttle.external.ExternalSerialThrottle` - a separate DShot/PWM
+  signal generator (e.g. an MCU bridge), for scripted DShot sequences or when
+  the stand can't emit the protocol you need.
+
+Throttle is always a normalized float in [0, 1]; each backend maps it to its
+native units (PWM microseconds, DShot 48..2047, stand output units).
+"""
+from __future__ import annotations
+
+import abc
+
+
+class ThrottleSource(abc.ABC):
+    @abc.abstractmethod
+    def arm(self) -> None:
+        """Bring the ESC to the armed/zero-throttle state."""
+
+    @abc.abstractmethod
+    def set(self, throttle: float) -> None:
+        """Command throttle in [0, 1]."""
+
+    def quiesce(self) -> None:
+        """Make the signal line idle LOW so the AM32 bootloader will jump to
+        the app on the next ESC reset. Zero throttle is not enough for DShot
+        (frames keep the line high 40-75% of the time); backends that can
+        drop the signal entirely should override this."""
+        self.set(0.0)
+
+    def disarm(self) -> None:
+        self.set(0.0)
+
+    def close(self) -> None:
+        pass
+
+    def __enter__(self) -> "ThrottleSource":
+        self.arm()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.disarm()
+        self.close()

--- a/hwci/hwci/throttle/external.py
+++ b/hwci/hwci/throttle/external.py
@@ -1,0 +1,54 @@
+"""External serial throttle source (DShot/PWM signal generator bridge).
+
+For runs where the ESC signal is produced by a dedicated generator rather than
+the Flight Stand - e.g. a small MCU (Arduino/Teensy/STM32) running a DShot
+generator, exposing a trivial serial protocol:
+
+    ARM\\n            -> arm / idle
+    T <0..2047>\\n    -> set DShot throttle value
+    DISARM\\n
+
+This keeps scripted DShot300/600 demag-stress sequences possible even if the
+stand only emits PWM. Swap in any generator by matching this line protocol, or
+subclass and override :meth:`_write`.
+"""
+from __future__ import annotations
+
+from .base import ThrottleSource
+
+DSHOT_MIN = 48
+DSHOT_MAX = 2047
+
+
+class ExternalSerialThrottle(ThrottleSource):
+    def __init__(self, port: str, baud: int = 115200):
+        self.port = port
+        self.baud = baud
+        self._ser = None
+
+    def _open(self):
+        import serial  # only needed on the rig
+        if self._ser is None:
+            self._ser = serial.Serial(self.port, self.baud, timeout=0.5)
+        return self._ser
+
+    def _write(self, line: str) -> None:
+        ser = self._open()
+        ser.write((line + "\n").encode())
+        ser.flush()
+
+    def arm(self) -> None:
+        self._write("ARM")
+
+    def set(self, throttle: float) -> None:
+        throttle = max(0.0, min(1.0, throttle))
+        value = int(DSHOT_MIN + throttle * (DSHOT_MAX - DSHOT_MIN))
+        self._write(f"T {value}")
+
+    def disarm(self) -> None:
+        self._write("DISARM")
+
+    def close(self) -> None:
+        if self._ser is not None:
+            self._ser.close()
+            self._ser = None

--- a/hwci/hwci/throttle/flightstand_src.py
+++ b/hwci/hwci/throttle/flightstand_src.py
@@ -1,0 +1,27 @@
+"""Throttle source that uses the Flight Stand's own ESC output."""
+from __future__ import annotations
+
+import time
+
+from ..flightstand.base import ThrustStand
+from .base import ThrottleSource
+
+
+class FlightStandThrottle(ThrottleSource):
+    def __init__(self, stand: ThrustStand, arm_settle_s: float = 1.0):
+        self.stand = stand
+        self.arm_settle_s = arm_settle_s
+
+    def arm(self) -> None:
+        self.stand.set_throttle(0.0)
+        # Hold zero throttle long enough for the ESC to arm.
+        time.sleep(self.arm_settle_s)
+
+    def set(self, throttle: float) -> None:
+        self.stand.set_throttle(throttle)
+
+    def quiesce(self) -> None:
+        # Deactivate the stand's ESC output entirely: the line is driven to
+        # logic 0, which is what lets the AM32 bootloader exit to the app
+        # (verified on the ARK 4IN1 bench; DShot-at-zero is NOT enough).
+        self.stand.deactivate()

--- a/hwci/pyproject.toml
+++ b/hwci/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "am32-hwci"
+version = "0.1.0"
+description = "Hardware-in-the-loop CI harness for AM32 on the ARK 4IN1 ESC"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "pyelftools>=0.29",   # read hwci_perf address + DWARF layout from the ELF
+    "pyserial>=3.5",      # KISS telemetry + optional external throttle source
+    "PyYAML>=6.0",        # test profiles / rig config
+    "numpy>=1.24",        # metric math
+]
+
+[project.optional-dependencies]
+plot = ["matplotlib>=3.7"]            # report plots
+flightstand = ["grpcio>=1.51"]        # real Flight Stand gRPC client
+dev = ["pytest>=7.0", "grpcio-tools>=1.51"]
+
+[project.scripts]
+hwci = "hwci.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["hwci*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/hwci/scripts/99-hwci.rules
+++ b/hwci/scripts/99-hwci.rules
@@ -1,0 +1,27 @@
+# udev rules for the AM32 hardware-CI bench.
+# Install: sudo cp 99-hwci.rules /etc/udev/rules.d/ && sudo udevadm control --reload-rules && sudo udevadm trigger
+
+# --- ST-Link debug probes (V2 / V2.1 / V3) -> accessible without root ---
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3744", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3748", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374d", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374e", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374f", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3753", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3754", MODE="0660", TAG+="uaccess"
+
+# --- SEGGER J-Link (if used instead of ST-Link) ---
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1366", MODE="0660", TAG+="uaccess"
+
+# --- Stable serial-port names ---------------------------------------------
+# Give the ESC telemetry adapter and (optional) external throttle generator
+# stable /dev names so rig.yaml doesn't depend on enumeration order.
+# Find your adapter's attributes with:
+#   udevadm info -a -n /dev/ttyUSB0 | grep -E 'idVendor|idProduct|serial'
+# then fill in idVendor/idProduct and the unique serial below.
+#
+# Example (CP2102 with serial 0001):
+# SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", ATTRS{serial}=="0001", SYMLINK+="esc-telem"
+# Example (FTDI with serial FT1ABCDE):
+# SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FT1ABCDE", SYMLINK+="esc-throttle"

--- a/hwci/scripts/setup_ubuntu.sh
+++ b/hwci/scripts/setup_ubuntu.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Provision an Ubuntu 24.04 box as an AM32 hardware-CI bench / self-hosted runner.
+# Idempotent: safe to re-run. Does NOT install the Flight Stand Software (vendor
+# binary) or generate its gRPC stubs - see hwci/README.md for those steps.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HWCI_DIR="$(dirname "$HERE")"
+REPO_ROOT="$(dirname "$HWCI_DIR")"
+
+echo "==> apt packages"
+sudo apt-get update
+sudo apt-get install -y build-essential git python3-venv python3-pip openocd usbutils
+
+echo "==> ARM toolchain"
+if ! ls "$REPO_ROOT"/tools/linux/*/bin/arm-none-eabi-gcc >/dev/null 2>&1 \
+   && ! command -v arm-none-eabi-gcc >/dev/null 2>&1; then
+  ( cd "$REPO_ROOT" && make arm_sdk_install ) || sudo apt-get install -y gcc-arm-none-eabi
+fi
+
+echo "==> udev rules (ST-Link + serial symlinks)"
+sudo cp "$HERE/99-hwci.rules" /etc/udev/rules.d/99-hwci.rules
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+
+echo "==> serial/usb group membership"
+sudo usermod -aG dialout,plugdev "$USER" || true
+
+echo "==> python harness venv"
+cd "$HWCI_DIR"
+python3 -m venv .venv
+# shellcheck disable=SC1091
+. .venv/bin/activate
+pip install --upgrade pip
+pip install -e '.[plot,flightstand,dev]'
+
+echo "==> self-test (simulator, no hardware needed)"
+python -m hwci selftest
+
+cat <<'EOF'
+
+Done. Remaining manual steps (see hwci/README.md):
+  1. Log out/in so dialout/plugdev group membership takes effect.
+  2. Install the Tyto Flight Stand Software and generate its gRPC Python stubs.
+  3. cp config/rig.example.yaml rig.yaml  and edit for your wiring.
+  4. Edit /etc/udev/rules.d/99-hwci.rules with your USB-serial serial numbers
+     so /dev/esc-telem and /dev/esc-throttle appear, then re-trigger udev.
+  5. Capture a baseline:  hwci ci --profile efficiency_sweep --config rig.yaml \
+        --out runs/baseline && hwci baseline-save runs/baseline \
+        --out baselines/ARK_4IN1_F051.json
+EOF

--- a/hwci/tests/conftest.py
+++ b/hwci/tests/conftest.py
@@ -1,0 +1,43 @@
+"""Shared test fixtures.
+
+``host_perf_elf`` compiles the real firmware header (Inc/hwci_perf.h) with the
+host C compiler into a small ELF carrying DWARF for ``hwci_perf_s`` and the
+``hwci_perf`` symbol. The struct is naturally aligned with members <= 4 bytes,
+so its layout is identical on the host and on the Cortex-M0 target.
+"""
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HEADER_DIR = REPO_ROOT / "Inc"
+_CC = shutil.which("cc") or shutil.which("gcc")
+
+_PROBE_C = """\
+#define HWCI_PERF 1
+#include "hwci_perf.h"
+volatile hwci_perf_t hwci_perf = {
+  .magic = HWCI_PERF_MAGIC, .version = HWCI_PERF_VERSION,
+  .size = (uint16_t)sizeof(hwci_perf_t) };
+void hwci_perf_apply_cmd(void) {}
+int main(void){ return (int)hwci_perf.size; }
+"""
+
+
+@pytest.fixture(scope="session")
+def host_perf_elf(tmp_path_factory):
+    pytest.importorskip("elftools")
+    if _CC is None:
+        pytest.skip("no host C compiler available")
+    if not (HEADER_DIR / "hwci_perf.h").exists():
+        pytest.skip("Inc/hwci_perf.h not found")
+    d = tmp_path_factory.mktemp("perf_elf")
+    src = d / "probe.c"
+    src.write_text(_PROBE_C)
+    out = d / "probe.elf"
+    subprocess.run(
+        [_CC, "-g", "-O0", f"-I{HEADER_DIR}", str(src), "-o", str(out)],
+        check=True, capture_output=True)
+    return str(out)

--- a/hwci/tests/test_app_alive.py
+++ b/hwci/tests/test_app_alive.py
@@ -1,0 +1,88 @@
+"""_ensure_app_alive: bootloader-stuck ESC recovery on live-source bring-up.
+
+On this rig the stand's inactive ESC output leaves the signal line high, and
+the AM32 bootloader then never jumps to the app after a flash/power-cycle
+(observed on the ARK 4IN1 bench: perf magic reads 0x00000000, PC loops in the
+bootloader). The runner must drive zero throttle, reset, and wait for the
+app's magic instead of handing a dead perf channel to the run.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hwci.perf import PerfDecodeError
+from hwci.runner import _ensure_app_alive
+
+
+class FakeReader:
+    """perf_reader.read() fails until the fake target has been reset."""
+
+    def __init__(self, alive_after_resets: int):
+        self.alive_after_resets = alive_after_resets
+        self.resets = 0
+
+    def read(self):
+        if self.resets >= self.alive_after_resets:
+            return object()
+        raise PerfDecodeError("bad magic 0x00000000")
+
+
+class FakeDbg:
+    def __init__(self, reader: FakeReader):
+        self._reader = reader
+
+    def reset_run(self):
+        self._reader.resets += 1
+
+
+class FakeThrottle:
+    def __init__(self):
+        self.commands = []
+
+    def set(self, throttle):
+        self.commands.append(throttle)
+
+    def quiesce(self):
+        self.commands.append("quiesce")
+
+
+def test_already_alive_touches_nothing():
+    reader = FakeReader(alive_after_resets=0)
+    dbg, throttle = FakeDbg(reader), FakeThrottle()
+    _ensure_app_alive(dbg, reader, throttle)
+    assert reader.resets == 0
+    assert throttle.commands == []
+
+
+def test_stuck_in_bootloader_recovers_via_reset():
+    reader = FakeReader(alive_after_resets=1)
+    dbg, throttle = FakeDbg(reader), FakeThrottle()
+    _ensure_app_alive(dbg, reader, throttle)
+    assert reader.resets == 1
+    # the signal must be DROPPED (not DShot-at-zero) before the reset so the
+    # line is driven low and the bootloader jumps to the app
+    assert throttle.commands == ["quiesce"]
+
+
+def test_never_alive_raises_actionable_error(monkeypatch):
+    # collapse the wait loops so the failure path is fast
+    import hwci.runner as runner
+    monkeypatch.setattr(runner.time, "sleep", lambda s: None)
+    clock = iter(range(0, 10_000))
+    monkeypatch.setattr(runner.time, "monotonic", lambda: float(next(clock)))
+
+    reader = FakeReader(alive_after_resets=99)
+    dbg, throttle = FakeDbg(reader), FakeThrottle()
+    with pytest.raises(RuntimeError, match="bootloader|HWCI_PERF"):
+        _ensure_app_alive(dbg, reader, throttle)
+    assert reader.resets == 2  # both attempts exhausted
+
+
+def test_debugger_error_propagates():
+    class DeadProbeReader:
+        def read(self):
+            raise ConnectionError("SWD gone")
+
+    reader = DeadProbeReader()
+    with pytest.raises(ConnectionError):
+        _ensure_app_alive(FakeDbg(FakeReader(0)), reader, FakeThrottle())

--- a/hwci/tests/test_baseline.py
+++ b/hwci/tests/test_baseline.py
@@ -1,0 +1,213 @@
+"""Tests for baseline save/compare regression gating."""
+import copy
+
+from hwci import baseline as bl
+from hwci import metrics as metricsmod
+from hwci.config import RigConfig, load_profile
+from hwci.runner import build_sim_sources, run_profile
+
+
+def _metrics(profile_name="ci_smoke"):
+    rig = RigConfig()
+    profile = load_profile(profile_name)
+    sources = build_sim_sources(rig, profile)
+    try:
+        result = run_profile(profile, sources, realtime=False, meta={})
+    finally:
+        sources.close()
+    return metricsmod.compute(result, profile)
+
+
+def test_identical_metrics_pass():
+    m = _metrics()
+    base = {"metrics": m}
+    result = bl.compare(m, base)
+    assert result["passed"]
+
+
+def test_efficiency_regression_fails():
+    m = _metrics()
+    base = {"metrics": copy.deepcopy(m)}
+    # 30% drop is well past the 15% gate (widened from an initial 3% guess
+    # after a same-firmware repeatability run showed up to 8.7% swing at
+    # high power on the physical bench - see Thresholds.efficiency_drop_pct).
+    m["summary"]["peak_efficiency_gf_per_w"] *= 0.70
+    for p in m["steady_points"]:
+        p["eff_gf_per_w"] *= 0.70
+    result = bl.compare(m, base)
+    assert not result["passed"]
+    assert any(c["name"] == "peak_efficiency_gf_per_w" and not c["pass"]
+               for c in result["checks"])
+
+
+def test_loop_time_regression_fails():
+    m = _metrics()
+    base = {"metrics": copy.deepcopy(m)}
+    # Well past both the +15% and the +45us absolute slack.
+    m["summary"]["worst_ctrl_exec_us_steady"] = (
+        base["metrics"]["summary"]["worst_ctrl_exec_us_steady"] + 100)
+    result = bl.compare(m, base)
+    assert not result["passed"]
+
+
+def test_loop_time_gate_prefers_steady_key():
+    m = _metrics()
+    base = {"metrics": copy.deepcopy(m)}
+    # A start-transient spike in the raw run-max must NOT fail the gate when
+    # the steady-window value is unchanged (observed 705 vs 950us run-to-run).
+    m["summary"]["worst_ctrl_exec_us"] = 950
+    result = bl.compare(m, base)
+    assert result["passed"]
+
+
+def test_loop_time_gate_falls_back_without_steady_key():
+    m = _metrics()
+    base = {"metrics": copy.deepcopy(m)}
+    del base["metrics"]["summary"]["worst_ctrl_exec_us_steady"]
+    m["summary"]["worst_ctrl_exec_us"] = (
+        base["metrics"]["summary"]["worst_ctrl_exec_us"] + 100)
+    result = bl.compare(m, base)
+    assert not result["passed"]
+
+
+def test_loop_time_equality_passes():
+    # A baseline must pass against itself even with large absolute values
+    # (950us start transients failed the old <=45us absolute-cap semantics).
+    m = _metrics()
+    base = {"metrics": copy.deepcopy(m)}
+    for k in ("worst_ctrl_exec_us", "worst_ctrl_exec_us_steady"):
+        base["metrics"]["summary"][k] = 950
+        m["summary"][k] = 950
+    assert bl.compare(m, base)["passed"]
+
+
+def test_negative_efficiency_equality_passes():
+    # Naive percent math fails an identical negative value against itself.
+    assert bl._worse_is_lower(-1.0, -1.0, 3.0)
+    assert not bl._worse_is_lower(-1.0, -1.06, 3.0)  # real 6% worsening fails
+    assert bl._worse_is_lower(9.0, 8.8, 3.0)         # positive within 3%
+
+
+def test_low_power_point_not_gated_even_with_prop():
+    # A real prop can still produce a low-power point (e.g. 10% throttle)
+    # where thrust/power is a ratio of two small noisy numbers - observed on
+    # the bench: 2.3W swung -73% efficiency run-to-run on unchanged hardware.
+    m = _metrics()
+    base = {"metrics": copy.deepcopy(m)}
+    base["metrics"]["steady_points"][0]["elec_power_w"] = 2.3
+    base["metrics"]["steady_points"][0]["eff_gf_per_w"] = 7.72
+    m["steady_points"][0]["elec_power_w"] = 2.3
+    m["steady_points"][0]["eff_gf_per_w"] = 2.05  # -73%, would fail the % gate
+    result = bl.compare(m, base)
+    label = base["metrics"]["steady_points"][0]["segment"]
+    eff_check = next(c for c in result["checks"] if c["name"] == f"eff@{label}")
+    assert eff_check["pass"]
+    assert "not gated" in eff_check["note"]
+
+
+def test_peak_efficiency_excludes_low_power_points():
+    # "Peak" is a max() over throttle points, which amplifies whichever point
+    # is noisiest. If the literal peak sits at a low-power point, the GATE
+    # must recompute peak from points above the power floor instead of
+    # trusting the summary scalar - else it gates pure noise every run.
+    m = _metrics()
+    base = {"metrics": copy.deepcopy(m)}
+    pts_b = base["metrics"]["steady_points"]
+    pts_c = m["steady_points"]
+    assert len(pts_b) >= 2
+    # Low-power point has the highest g/W in both runs (as observed on the
+    # bench) but swings wildly; a real, well-powered point stays stable.
+    pts_b[0]["elec_power_w"], pts_b[0]["eff_gf_per_w"] = 2.3, 50.0
+    pts_c[0]["elec_power_w"], pts_c[0]["eff_gf_per_w"] = 2.3, 5.0
+    pts_b[1]["elec_power_w"], pts_b[1]["eff_gf_per_w"] = 100.0, 1.0
+    pts_c[1]["elec_power_w"], pts_c[1]["eff_gf_per_w"] = 100.0, 1.0
+    result = bl.compare(m, base)
+    peak_check = next(c for c in result["checks"]
+                      if c["name"] == "peak_efficiency_gf_per_w")
+    assert peak_check["baseline"] == 1.0   # not 50.0 - the noisy point excluded
+    assert peak_check["current"] == 1.0
+    assert peak_check["pass"]
+
+
+def test_noprop_efficiency_noise_not_gated():
+    m = _metrics()
+    base = {"metrics": copy.deepcopy(m)}
+    # No-prop rig: baseline g/W is noise around zero; must not gate at all.
+    base["metrics"]["summary"]["peak_efficiency_gf_per_w"] = -0.218
+    m["summary"]["peak_efficiency_gf_per_w"] = 0.3  # different noise, still ok
+    for p in base["metrics"]["steady_points"]:
+        p["eff_gf_per_w"] = -0.1
+    for p in m["steady_points"]:
+        p["eff_gf_per_w"] = 0.2
+    result = bl.compare(m, base)
+    assert result["passed"]
+    assert any("not gated" in c["note"] for c in result["checks"])
+
+
+def test_new_demag_fails():
+    m = _metrics()
+    base = {"metrics": copy.deepcopy(m)}
+    base["metrics"]["summary"]["demag_events"] = 0
+    m["summary"]["demag_events"] = 2
+    result = bl.compare(m, base)
+    assert not result["passed"]
+
+
+def test_save_and_load(tmp_path):
+    m = _metrics()
+    path = bl.save_baseline(m, tmp_path / "base.json", meta={"target": "X"})
+    loaded = bl.load_baseline(path)
+    assert loaded["format_version"] == bl.FORMAT_VERSION
+    assert loaded["metrics"]["summary"]["max_thrust_gf"] == m["summary"]["max_thrust_gf"]
+    assert loaded["meta"]["target"] == "X"
+
+
+# --- fail-closed behaviour --------------------------------------------------
+
+def test_missing_current_metric_fails():
+    m = _metrics()
+    base = {"metrics": copy.deepcopy(m)}
+    m["summary"]["worst_ctrl_exec_us_steady"] = None  # dead perf channel
+    result = bl.compare(m, base)
+    assert not result["passed"]
+    assert any(c["name"] == "worst_ctrl_exec_us_steady" and not c["pass"]
+               for c in result["checks"])
+
+
+def test_nan_current_metric_fails():
+    m = _metrics()
+    base = {"metrics": copy.deepcopy(m)}
+    m["summary"]["max_cpu_load_pct"] = float("nan")
+    result = bl.compare(m, base)
+    assert not result["passed"]
+
+
+def test_dead_channel_coverage_fails():
+    m = _metrics()
+    base = {"metrics": copy.deepcopy(m)}
+    # Perf channel died mid-run: only a handful of samples made it.
+    m["summary"]["perf_sample_count"] = 3
+    result = bl.compare(m, base)
+    assert any(c["name"] == "perf_coverage" and not c["pass"]
+               for c in result["checks"])
+    assert not result["passed"]
+
+
+def test_identity_mismatch_fails():
+    m = _metrics()
+    base = {"meta": {"target": "OTHER_TARGET", "profile": "ci_smoke"},
+            "metrics": copy.deepcopy(m)}
+    result = bl.compare(m, base,
+                        current_meta={"target": "ARK_4IN1_F051",
+                                      "profile": "ci_smoke"})
+    assert not result["passed"]
+    assert any(c["name"] == "baseline_target" and not c["pass"]
+               for c in result["checks"])
+
+
+def test_missing_steady_segment_fails():
+    m = _metrics()
+    base = {"metrics": copy.deepcopy(m)}
+    m["steady_points"] = m["steady_points"][:-1]  # a segment produced no data
+    result = bl.compare(m, base)
+    assert not result["passed"]

--- a/hwci/tests/test_battery.py
+++ b/hwci/tests/test_battery.py
@@ -1,0 +1,73 @@
+"""Pre-flight battery check: refuse to arm a test on a pack that's already
+too low for its declared cell count (see check_battery/_live_voltage in
+hwci/runner.py, wired into build_live_sources)."""
+import pytest
+
+from hwci.perf import PerfSample
+from hwci.runner import (DEFAULT_MIN_CELL_VOLTAGE, BatteryTooLowError,
+                         _live_voltage, check_battery)
+
+
+class _FakeStand:
+    def __init__(self, voltage_v):
+        self._voltage_v = voltage_v
+
+    def read_sample(self):
+        return type("Sample", (), {"voltage_v": self._voltage_v})()
+
+
+def _boom():
+    raise RuntimeError("SWD gone")
+
+
+# --------------------------------------------------------------------------
+# check_battery: pure threshold logic
+# --------------------------------------------------------------------------
+def test_healthy_6s_pack_passes():
+    check_battery(24.9, battery_cells=6)  # 4.15 V/cell - matches bench baseline
+
+
+def test_6s_pack_below_default_cutoff_raises():
+    with pytest.raises(BatteryTooLowError, match="6S"):
+        check_battery(18.5, battery_cells=6)  # 3.08 V/cell < 3.3 V/cell default
+
+
+def test_error_message_names_actual_and_minimum_voltage():
+    with pytest.raises(BatteryTooLowError) as exc_info:
+        check_battery(18.5, battery_cells=6)
+    msg = str(exc_info.value)
+    assert "18.50" in msg
+    assert f"{6 * DEFAULT_MIN_CELL_VOLTAGE:.2f}" in msg
+
+
+def test_unverifiable_voltage_fails_closed():
+    with pytest.raises(BatteryTooLowError, match="cannot verify"):
+        check_battery(None, battery_cells=6)
+
+
+def test_custom_cutoff_overrides_default():
+    check_battery(19.0, battery_cells=6, min_cell_voltage=3.0)  # 3.17 V/cell, above 3.0 floor
+    with pytest.raises(BatteryTooLowError):
+        check_battery(19.0, battery_cells=6, min_cell_voltage=3.3)  # same pack, stricter floor
+
+
+def test_boundary_voltage_is_not_too_low():
+    # exactly at the minimum should pass (strict "<" in the implementation)
+    check_battery(6 * DEFAULT_MIN_CELL_VOLTAGE, battery_cells=6)
+
+
+# --------------------------------------------------------------------------
+# _live_voltage: stand preferred, perf struct as fallback
+# --------------------------------------------------------------------------
+def test_live_voltage_reads_stand_when_present():
+    stand = _FakeStand(voltage_v=22.2)
+    assert _live_voltage(stand, perf_source=_boom) == 22.2  # perf never consulted
+
+
+def test_live_voltage_falls_back_to_perf_without_a_stand():
+    pf = PerfSample(raw={"voltage_cv": 2210})
+    assert _live_voltage(None, perf_source=lambda: pf) == pytest.approx(22.10)
+
+
+def test_live_voltage_none_when_no_stand_and_perf_unreadable():
+    assert _live_voltage(None, perf_source=_boom) is None

--- a/hwci/tests/test_cli.py
+++ b/hwci/tests/test_cli.py
@@ -1,0 +1,82 @@
+"""CLI-layer tests: sim/hw mode selection, baseline bootstrap, self-describing runs."""
+import argparse
+
+from hwci import cli
+from hwci.config import RigConfig, load_profile
+from hwci.model import RunResult
+from hwci.runner import DEFAULT_MIN_CELL_VOLTAGE
+
+
+def _ns(**kw):
+    return argparse.Namespace(**kw)
+
+
+def test_sim_requires_explicit_flag_or_no_config():
+    assert cli._use_sim(_ns(sim=True, config="rig.yaml"))
+    assert cli._use_sim(_ns(sim=False, config=None))
+    # A rig config without --sim is ALWAYS a hardware run - a sim backend
+    # value can no longer flip it (load_rig rejects sim backends anyway).
+    assert not cli._use_sim(_ns(sim=False, config="rig.yaml"))
+
+
+def test_missing_baseline_warns_and_skips(tmp_path, capsys):
+    assert cli._load_baseline(str(tmp_path / "nope.json")) is None
+    assert "not found" in capsys.readouterr().err
+    assert cli._load_baseline(None) is None
+
+
+def test_profile_for_prefers_embedded_definition():
+    profile = load_profile("ci_smoke")
+    edited = cli.profile_to_dict(profile)
+    edited["demag_rpm_drop_fraction"] = 0.11  # differs from today's YAML
+    result = RunResult(meta={"profile": "ci_smoke", "profile_def": edited})
+    assert cli._profile_for(result).demag_rpm_drop_fraction == 0.11
+    # No embedded definition -> falls back to loading by name.
+    legacy = RunResult(meta={"profile": "ci_smoke"})
+    assert cli._profile_for(legacy).name == "ci_smoke"
+
+
+def test_selftest_runs_clean(capsys):
+    rc = cli.cmd_selftest(_ns(profile="ci_smoke"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "steady points" in out
+
+
+def test_run_and_ci_expose_battery_flags_with_defaults():
+    parser = cli.build_parser()
+    run_ns = parser.parse_args(["run", "--profile", "ci_smoke"])
+    assert run_ns.battery_cells is None
+    assert run_ns.min_cell_voltage == DEFAULT_MIN_CELL_VOLTAGE
+
+    ci_ns = parser.parse_args(["ci", "--battery-cells", "6",
+                               "--min-cell-voltage", "3.5"])
+    assert ci_ns.battery_cells == 6
+    assert ci_ns.min_cell_voltage == 3.5
+
+
+def test_run_and_ci_expose_no_tare_flag():
+    parser = cli.build_parser()
+    assert parser.parse_args(["run", "--profile", "ci_smoke"]).no_tare is False
+    assert parser.parse_args(["ci", "--no-tare"]).no_tare is True
+
+
+def test_sim_runs_are_never_marked_tared():
+    # The simulator has no load cells to zero; meta must say so even when
+    # taring wasn't explicitly disabled, or a sim run dir would claim a
+    # pre-flight step that never happened.
+    rig = RigConfig()
+    profile = load_profile("ci_smoke")
+    result = cli._execute(rig, profile, sim=True)
+    assert result.meta["tared"] is False
+
+
+def test_battery_check_does_not_apply_in_sim_mode():
+    # The built-in simulator's nominal pack voltage doesn't represent any
+    # particular real cell count, so --battery-cells must be a no-op under
+    # --sim rather than spuriously aborting every simulated/offline run.
+    rig = RigConfig()
+    profile = load_profile("ci_smoke")
+    result = cli._execute(rig, profile, sim=True, battery_cells=6)
+    assert result.meta["aborted"] is None
+    assert result.meta["battery_cells"] == 6  # still recorded for the record

--- a/hwci/tests/test_config.py
+++ b/hwci/tests/test_config.py
@@ -1,0 +1,76 @@
+"""Tests for strict rig-config validation and profile (de)serialization."""
+import pytest
+
+from hwci.config import (RigConfig, load_profile, load_rig,
+                         profile_from_dict, profile_to_dict)
+
+VALID_RIG = """\
+target: ARK_4IN1_F051
+debugger_backend: openocd
+telem_backend: serial
+throttle_backend: flightstand
+stand_backend: grpc
+pole_pairs: 11
+"""
+
+
+def _write(tmp_path, text):
+    p = tmp_path / "rig.yaml"
+    p.write_text(text)
+    return str(p)
+
+
+def test_valid_rig_loads(tmp_path):
+    rig = load_rig(_write(tmp_path, VALID_RIG))
+    assert rig.debugger_backend == "openocd"
+    assert rig.pole_pairs == 11
+
+
+def test_unknown_key_rejected(tmp_path):
+    with pytest.raises(ValueError, match="unknown key"):
+        load_rig(_write(tmp_path, VALID_RIG + "debugger_bakend: openocd\n"))
+
+
+def test_unknown_backend_value_rejected(tmp_path):
+    bad = VALID_RIG.replace("stand_backend: grpc", "stand_backend: gprc")
+    with pytest.raises(ValueError, match="stand_backend"):
+        load_rig(_write(tmp_path, bad))
+
+
+def test_sim_backend_rejected_in_rig_file(tmp_path):
+    bad = VALID_RIG.replace("stand_backend: grpc", "stand_backend: sim")
+    with pytest.raises(ValueError, match="not allowed in a rig file"):
+        load_rig(_write(tmp_path, bad))
+
+
+def test_omitted_backend_rejected_in_rig_file(tmp_path):
+    # An omitted backend would default to "sim" - a rig file must be explicit.
+    partial = VALID_RIG.replace("telem_backend: serial\n", "")
+    with pytest.raises(ValueError, match="telem_backend"):
+        load_rig(_write(tmp_path, partial))
+
+
+def test_flightstand_throttle_needs_a_stand(tmp_path):
+    bad = VALID_RIG.replace("stand_backend: grpc", "stand_backend: none")
+    with pytest.raises(ValueError, match="flightstand"):
+        load_rig(_write(tmp_path, bad))
+
+
+def test_none_backends_allowed(tmp_path):
+    text = VALID_RIG.replace("stand_backend: grpc", "stand_backend: none")
+    text = text.replace("throttle_backend: flightstand",
+                        "throttle_backend: external")
+    rig = load_rig(_write(tmp_path, text))
+    assert rig.stand_backend == "none"
+
+
+def test_no_config_gives_sim_defaults():
+    rig = load_rig(None)
+    assert rig.stand_backend == "sim"
+    rig.validate()  # sim allowed for the built-in default
+
+
+def test_profile_roundtrips_through_dict():
+    p = load_profile("demag_step_stress")
+    q = profile_from_dict(profile_to_dict(p))
+    assert q == p

--- a/hwci/tests/test_elf.py
+++ b/hwci/tests/test_elf.py
@@ -1,0 +1,35 @@
+"""Tests for ELF symbol + DWARF struct-layout extraction."""
+import struct
+
+import pytest
+
+pytest.importorskip("elftools")
+
+from hwci import elf, perf  # noqa: E402
+
+
+def test_find_symbol(host_perf_elf):
+    sym = elf.find_symbol(host_perf_elf, "hwci_perf")
+    assert sym.size == perf.SIZE == 64
+
+
+def test_dwarf_layout_matches_canonical(host_perf_elf):
+    members = {m.name: m for m in elf.struct_layout(host_perf_elf, "hwci_perf_s")}
+    offset = 0
+    for name, code in perf.FIELDS:
+        size = struct.calcsize(code)
+        if not name.startswith("_pad"):
+            assert name in members, f"{name} missing from DWARF"
+            assert members[name].offset == offset, (
+                f"{name}: DWARF off {members[name].offset} != canonical {offset}")
+            assert members[name].size == size, (
+                f"{name}: DWARF size {members[name].size} != canonical {size}")
+            assert members[name].signed == (code in ("b", "h", "i")), (
+                f"{name}: signedness mismatch")
+        offset += size
+    assert offset == perf.SIZE
+
+
+def test_missing_symbol_raises(host_perf_elf):
+    with pytest.raises(elf.ElfError):
+        elf.find_symbol(host_perf_elf, "definitely_not_a_symbol")

--- a/hwci/tests/test_flightstand_sim.py
+++ b/hwci/tests/test_flightstand_sim.py
@@ -1,0 +1,48 @@
+"""Tests for the simulated Flight Stand backend."""
+import pytest
+
+from hwci.flightstand.base import SafetyLimits
+from hwci.flightstand.simulator import SimulatedStand, StandSafetyTripped
+from hwci.sim import MotorParams, RigSimulator
+
+
+def _stand(**kw):
+    # Deterministic: fixed timestep, no noise.
+    rig = RigSimulator(params=kw.pop("params", MotorParams()), noise=0.0)
+    return SimulatedStand(rig, fixed_dt=0.01).open()
+
+
+def test_throttle_produces_thrust():
+    stand = _stand()
+    stand.set_throttle(0.7)
+    last = None
+    for _ in range(200):
+        last = stand.read_sample()
+    assert last.thrust_n > 0
+    assert last.rpm > 1000
+    assert last.efficiency_gf_per_w > 0
+
+
+def test_zero_throttle_zero_thrust():
+    stand = _stand()
+    stand.set_throttle(0.0)
+    for _ in range(50):
+        s = stand.read_sample()
+    assert s.thrust_n == pytest.approx(0.0, abs=1e-6)
+
+
+def test_safety_limit_trips():
+    stand = _stand()
+    stand.set_safety_limits(SafetyLimits(max_current_a=5.0))
+    stand.set_throttle(1.0)
+    with pytest.raises(StandSafetyTripped):
+        for _ in range(500):
+            stand.read_sample()
+
+
+def test_context_manager_zeroes_on_exit():
+    rig = RigSimulator(noise=0.0)
+    with SimulatedStand(rig, fixed_dt=0.01) as stand:
+        stand.set_throttle(0.5)
+        stand.read_sample()
+    assert stand._throttle == 0.0

--- a/hwci/tests/test_kiss.py
+++ b/hwci/tests/test_kiss.py
@@ -1,0 +1,81 @@
+"""Tests for the KISS ESC telemetry decoder."""
+import struct
+
+from hwci.esc_telem import crc8, encode_frame, parse_frame
+from hwci.esc_telem.kiss import KissStream
+
+
+def _make_frame(temp, volt_cv, cur_ca, cons, erpm100):
+    body = struct.pack(">bHHHH", temp, volt_cv, cur_ca, cons, erpm100)
+    return body + bytes([crc8(body)])
+
+
+def test_crc8_known_vector():
+    # CRC of an all-zero 9-byte body is 0 for this polynomial/init.
+    assert crc8(b"\x00" * 9) == 0
+
+
+def test_crc8_table_matches_bitwise_reference():
+    def crc8_bitwise(data):
+        crc = 0
+        for byte in data:
+            crc ^= byte
+            for _ in range(8):
+                crc = ((crc << 1) ^ 0x07) & 0xFF if crc & 0x80 else (crc << 1) & 0xFF
+        return crc
+    for vec in (b"\x01", b"\xff" * 9, bytes(range(9)), b"\xa5\x5a\x00\x42"):
+        assert crc8(vec) == crc8_bitwise(vec)
+
+
+def test_encode_parse_roundtrip():
+    blob = encode_frame(temperature_c=42, voltage_cv=1650, current_ca=1234,
+                        consumption_mah=56, erpm100=200)
+    f = parse_frame(blob)
+    assert f.crc_ok
+    assert (f.temperature_c, f.voltage_v, f.current_a,
+            f.consumption_mah, f.e_rpm) == (42, 16.5, 12.34, 56, 20000)
+
+
+def test_parse_valid_frame():
+    frame = _make_frame(temp=42, volt_cv=1650, cur_ca=1234, cons=56, erpm100=200)
+    f = parse_frame(frame)
+    assert f.crc_ok
+    assert f.temperature_c == 42
+    assert f.voltage_v == 1650 / 100.0
+    assert f.current_a == 1234 / 100.0
+    assert f.consumption_mah == 56
+    assert f.e_rpm == 20000
+
+
+def test_bad_crc_flagged():
+    frame = bytearray(_make_frame(20, 1600, 100, 1, 100))
+    frame[-1] ^= 0xFF
+    f = parse_frame(bytes(frame))
+    assert not f.crc_ok
+
+
+def test_stream_resync_after_garbage():
+    good = _make_frame(25, 1600, 500, 10, 150)
+    stream = KissStream()
+    # Prepend 3 junk bytes; the framer must slide past them and recover.
+    frames = list(stream.feed(b"\x11\x22\x33" + good))
+    assert len(frames) == 1
+    assert frames[0].temperature_c == 25
+    assert frames[0].e_rpm == 15000
+
+
+def test_stream_multiple_frames():
+    f1 = _make_frame(10, 1500, 100, 1, 50)
+    f2 = _make_frame(11, 1510, 110, 2, 60)
+    stream = KissStream()
+    out = list(stream.feed(f1 + f2))
+    assert [f.temperature_c for f in out] == [10, 11]
+
+
+def test_stream_partial_then_complete():
+    f = _make_frame(30, 1700, 800, 20, 250)
+    stream = KissStream()
+    assert list(stream.feed(f[:6])) == []   # nothing yet
+    out = list(stream.feed(f[6:]))
+    assert len(out) == 1
+    assert out[0].e_rpm == 25000

--- a/hwci/tests/test_metrics.py
+++ b/hwci/tests/test_metrics.py
@@ -1,0 +1,141 @@
+"""Metric-math tests on synthetic rows: demag channels and CPU-load robustness."""
+from hwci import metrics as metricsmod
+from hwci.config import Profile, Segment
+from hwci.model import RunResult
+
+
+def _profile():
+    return Profile(name="synthetic", sample_rate_hz=100.0,
+                   segments=[Segment(label="hold", throttle=0.9,
+                                     duration_s=1.0, steady=True)])
+
+
+def _rows(n, **cols):
+    """n rows at 100 Hz; cols maps column -> list or callable(i)."""
+    rows = []
+    for i in range(n):
+        row = {"t": i * 0.01, "segment": "hold", "throttle_cmd": 0.9}
+        for k, v in cols.items():
+            row[k] = v(i) if callable(v) else v[i]
+        rows.append(row)
+    return rows
+
+
+def test_bemf_counter_values_all_count():
+    # Firmware bemf_timeout_happened is a counter (2, 3, ... latched at 102),
+    # not a boolean - every non-zero sample is a timeout state.
+    vals = [0, 0, 1, 2, 50, 102, 0, 0, 0, 0]
+    rows = _rows(len(vals), perf_bemf_timeout=vals)
+    d = metricsmod.detect_demag(RunResult(rows=rows), _profile())
+    assert d["bemf_timeout_samples"] == 4
+    assert d["event_count"] >= 1
+
+
+def test_rpm_collapse_detected_at_high_throttle():
+    # Steady 90% throttle; RPM collapses 40% mid-segment (desync whose
+    # transient firmware flags fell between SWD samples).
+    rpm = [20000.0] * 30 + [11000.0] * 10 + [20000.0] * 60
+    rows = _rows(len(rpm), stand_rpm=rpm)
+    d = metricsmod.detect_demag(RunResult(rows=rows), _profile())
+    assert d["rpm_drop_samples"] >= 5
+    assert d["event_count"] >= 1
+
+
+def test_spoolup_is_not_a_collapse():
+    # RPM rising monotonically after a step must not flag (the reference is
+    # the running max, which trails a rising signal).
+    rpm = [5000.0 + 150.0 * i for i in range(100)]
+    rows = _rows(len(rpm), stand_rpm=rpm)
+    d = metricsmod.detect_demag(RunResult(rows=rows), _profile())
+    assert d["rpm_drop_samples"] == 0
+
+
+def test_smooth_rampdown_is_not_a_collapse():
+    # A multi-second ramp-down moves throttle by a tiny amount each 10ms
+    # tick; RPM falling in lockstep with a commanded ramp-down is expected
+    # deceleration, not desync (observed false positive on the bench: a
+    # efficiency_sweep 100%->0% rampdn flagged with zero bemf timeouts,
+    # commutation spikes, or eRPM mismatch).
+    n = 400  # 4s at 100Hz
+    throttle = [1.0 - 1.0 * i / (n - 1) for i in range(n)]  # smooth 1.0 -> 0.0
+    rpm = [28000.0 * t for t in throttle]  # RPM tracks throttle exactly
+    rows = []
+    for i in range(n):
+        rows.append({"t": i * 0.01, "segment": "rampdn",
+                     "throttle_cmd": throttle[i], "stand_rpm": rpm[i]})
+    d = metricsmod.detect_demag(
+        RunResult(rows=rows),
+        Profile(name="synthetic", sample_rate_hz=100.0,
+               segments=[Segment(label="rampdn", throttle=0.0,
+                                 duration_s=4.0, ramp=True)]))
+    assert d["rpm_drop_samples"] == 0
+    assert d["event_count"] == 0
+
+
+def test_collapse_during_ramp_up_still_detected():
+    # The trend-based gate must not blind the detector to a real collapse
+    # that happens to occur while throttle is rising.
+    n = 60
+    throttle = [0.5 + 0.4 * i / (n - 1) for i in range(n)]  # 0.5 -> 0.9 rising
+    rpm = [20000.0 + 100.0 * i for i in range(n)]
+    for i in range(20, 30):
+        rpm[i] = 11000.0  # desync collapse mid-ramp, throttle still rising
+    rows = []
+    for i in range(n):
+        rows.append({"t": i * 0.01, "segment": "rampup",
+                     "throttle_cmd": throttle[i], "stand_rpm": rpm[i]})
+    d = metricsmod.detect_demag(
+        RunResult(rows=rows),
+        Profile(name="synthetic", sample_rate_hz=100.0,
+               segments=[Segment(label="rampup", throttle=0.9,
+                                 duration_s=0.6, ramp=True)]))
+    assert d["rpm_drop_samples"] >= 5
+    assert d["event_count"] >= 1
+
+
+def test_rig_pole_pairs_from_meta_overrides_profile():
+    # rig meta says 11 pole pairs; profile default is 7. eRPM 154000 at
+    # 14000 stand RPM matches 11pp exactly -> no mismatch when meta is used.
+    n = 50
+    rows = _rows(n, stand_rpm=lambda i: 14000.0, esc_erpm=lambda i: 154000)
+    d = metricsmod.detect_demag(
+        RunResult(meta={"pole_pairs": 11}, rows=rows), _profile())
+    assert d["esc_rpm_mismatch_samples"] == 0
+    d7 = metricsmod.detect_demag(RunResult(meta={}, rows=rows), _profile())
+    assert d7["esc_rpm_mismatch_samples"] == n  # wrong pp -> pervasive mismatch
+
+
+def test_cpu_load_idle_rate_ignores_stall_glitch():
+    # 120k iters/s idle; one sample pair spans a 100 ms host stall (11x the
+    # iteration delta) - a max-based idle rate would scale every other
+    # sample to ~91% load; the median must shrug it off.
+    n = 100
+    rows = []
+    iters = 0
+    for i in range(n):
+        di = 1200 if i != 50 else 1200 * 11  # the stall sample
+        iters += di
+        rows.append({"t": i * 0.01, "segment": "idle", "throttle_cmd": 0.0,
+                     "perf_loop_iters": iters})
+    m = metricsmod._cpu_load(rows)
+    load, idle_rate = m
+    assert abs(idle_rate - 120000.0) < 1000.0
+
+
+def test_cpu_load_prefers_perf_host_t():
+    # Same counter stream, but perf_host_t records the TRUE read times
+    # including the stall - the rate stays flat and load stays ~0 everywhere.
+    n = 100
+    rows = []
+    iters = 0
+    t_true = 0.0
+    for i in range(n):
+        dt_true = 0.01 if i != 50 else 0.11  # actual wall clock incl. stall
+        t_true += dt_true
+        iters += int(120000 * dt_true)
+        rows.append({"t": i * 0.01, "segment": "idle", "throttle_cmd": 0.0,
+                     "perf_loop_iters": iters, "perf_host_t": t_true})
+    load, idle_rate = metricsmod._cpu_load(rows)
+    assert abs(idle_rate - 120000.0) < 1500.0
+    import numpy as np
+    assert np.nanmax(load) < 5.0

--- a/hwci/tests/test_perf.py
+++ b/hwci/tests/test_perf.py
@@ -1,0 +1,73 @@
+"""Tests for the hwci_perf struct decoder."""
+import struct
+
+import pytest
+
+from hwci import perf
+
+
+def test_layout_is_64_bytes():
+    assert perf.SIZE == 64
+
+
+def test_host_cmd_offset_matches_layout():
+    # host_cmd is the final u32 in the 64-byte struct.
+    assert perf.HOST_CMD_OFFSET == 60
+
+
+def test_roundtrip_encode_decode():
+    sample = {
+        "ctrl_exec_us_max": 18,
+        "ctrl_period_us_min": 49,
+        "ctrl_period_us_max": 53,
+        "main_loop_us_max": 12,
+        "loop_iters": 123456,
+        "zero_cross_count": 9001,
+        "voltage_cv": 1612,     # 16.12 V
+        "current_ca": 2550,     # 25.50 A
+        "e_rpm": 321,           # 32100 eRPM
+        "temperature_c": 47,
+        "armed": 1,
+        "running": 1,
+        "commutation_interval": 110,
+    }
+    blob = perf.encode(sample)
+    assert len(blob) == perf.SIZE
+    decoded = perf.decode(blob)
+    assert decoded.ctrl_exec_us_max == 18
+    assert decoded.ctrl_period_us_min == 49
+    assert decoded.loop_iters == 123456
+    assert decoded.voltage == pytest.approx(16.12)
+    assert decoded.current == pytest.approx(25.50)
+    assert decoded.e_rpm == 32100
+
+
+def test_mech_rpm():
+    blob = perf.encode({"e_rpm": 140})  # 14000 eRPM
+    s = perf.decode(blob)
+    assert s.mech_rpm(7) == pytest.approx(2000.0)
+
+
+def test_bad_magic_raises():
+    blob = bytearray(perf.encode({}))
+    struct.pack_into("<I", blob, 0, 0xDEADBEEF)
+    with pytest.raises(perf.PerfDecodeError):
+        perf.decode(bytes(blob))
+
+
+def test_version_mismatch_raises():
+    blob = bytearray(perf.encode({}))
+    struct.pack_into("<H", blob, 4, 99)
+    with pytest.raises(perf.PerfDecodeError):
+        perf.decode(bytes(blob))
+
+
+def test_short_buffer_raises():
+    with pytest.raises(perf.PerfDecodeError):
+        perf.decode(b"\x00" * 10)
+
+
+def test_negative_current_is_signed():
+    blob = perf.encode({"current_ca": -150})
+    s = perf.decode(blob)
+    assert s.current == pytest.approx(-1.5)

--- a/hwci/tests/test_perf_reader.py
+++ b/hwci/tests/test_perf_reader.py
@@ -1,0 +1,81 @@
+"""Tests for PerfReader against the in-memory MockDebugger."""
+import pytest
+
+pytest.importorskip("elftools")
+
+from hwci import perf  # noqa: E402
+from hwci.debugger.base import MockDebugger  # noqa: E402
+from hwci.perf_reader import PerfReader  # noqa: E402
+
+
+def _reader_with_mock(elf_path):
+    # Find the symbol address from the ELF, then map the mock memory there.
+    from hwci import elf as elfmod
+    addr = elfmod.find_symbol(elf_path, "hwci_perf").address
+    dbg = MockDebugger(base=addr, size=perf.SIZE + 256)
+    reader = PerfReader(dbg, elf_path)
+    return reader, dbg
+
+
+def test_read_decodes_seeded_struct(host_perf_elf):
+    reader, dbg = _reader_with_mock(host_perf_elf)
+    dbg.poke(reader.address, perf.encode({
+        "ctrl_exec_us_max": 21,
+        "loop_iters": 5000,
+        "voltage_cv": 1580,
+    }))
+    sample = reader.read()
+    assert sample.ctrl_exec_us_max == 21
+    assert sample.loop_iters == 5000
+    assert sample.voltage == pytest.approx(15.80)
+    assert sample.host_monotonic is not None
+
+
+def test_reset_stats_writes_command(host_perf_elf):
+    reader, dbg = _reader_with_mock(host_perf_elf)
+    dbg.poke(reader.address, perf.encode({}))
+    reader.reset_stats(verify=False)
+    word = dbg.read_memory(reader.address + perf.HOST_CMD_OFFSET, 4)
+    assert int.from_bytes(word, "little") == perf.CMD_RESET_STATS
+
+
+class _FirmwareLikeMock(MockDebugger):
+    """Consumes host_cmd immediately, like the firmware's apply_cmd."""
+
+    def write_u32(self, addr: int, value: int) -> None:
+        super().write_u32(addr, 0)  # command applied and cleared
+
+
+def test_reset_stats_verify_passes_when_consumed(host_perf_elf):
+    from hwci import elf as elfmod
+    addr = elfmod.find_symbol(host_perf_elf, "hwci_perf").address
+    dbg = _FirmwareLikeMock(base=addr, size=perf.SIZE + 256)
+    reader = PerfReader(dbg, host_perf_elf)
+    dbg.poke(reader.address, perf.encode({}))
+    reader.reset_stats()  # must not raise
+
+
+def test_reset_stats_verify_times_out_when_not_consumed(host_perf_elf):
+    from hwci.debugger.base import DebuggerError
+    reader, dbg = _reader_with_mock(host_perf_elf)
+    dbg.poke(reader.address, perf.encode({}))
+    with pytest.raises(DebuggerError):
+        reader.reset_stats(timeout_s=0.05)
+
+
+def test_layout_check_passes_for_real_header(host_perf_elf):
+    # Should not raise: DWARF layout matches canonical perf.FIELDS.
+    reader, _ = _reader_with_mock(host_perf_elf)
+    assert reader.address > 0
+
+
+def test_missing_struct_die_fails_hard(host_perf_elf, monkeypatch):
+    # DWARF present but the struct tag gone (rename/LTO): decoding on faith is
+    # exactly the drift the cross-check exists to catch -> must raise.
+    import hwci.perf_reader as pr
+    monkeypatch.setattr(pr, "STRUCT_TAG", "definitely_not_a_struct")
+    from hwci import elf as elfmod
+    addr = elfmod.find_symbol(host_perf_elf, "hwci_perf").address
+    dbg = MockDebugger(base=addr, size=perf.SIZE + 256)
+    with pytest.raises(perf.PerfDecodeError):
+        PerfReader(dbg, host_perf_elf)

--- a/hwci/tests/test_runner_safety.py
+++ b/hwci/tests/test_runner_safety.py
@@ -1,0 +1,78 @@
+"""Runner-level (host-side) safety enforcement - must trip on ANY rig, even
+when the stand backend does no checking of its own."""
+from hwci.config import Profile, Segment
+from hwci.esc_telem.kiss import KissFrame
+from hwci.flightstand.base import SafetyLimits
+from hwci.flightstand.simulator import SimulatedStand
+from hwci.runner import Sources, run_profile
+from hwci.sim import MotorParams, RigSimulator
+from hwci.throttle.flightstand_src import FlightStandThrottle
+
+
+def _profile(**safety):
+    return Profile(
+        name="safety-test",
+        sample_rate_hz=100.0,
+        segments=[Segment(label="wot", throttle=1.0, duration_s=2.0)],
+        safety=SafetyLimits(**safety),
+    )
+
+
+def _frame(current_a: float, temp_c: int = 30) -> KissFrame:
+    return KissFrame(temperature_c=temp_c, voltage_v=16.0, current_a=current_a,
+                     consumption_mah=0, e_rpm=10000, crc_ok=True)
+
+
+def test_runner_trips_on_stand_current_without_backend_limits():
+    # The stand itself gets NO limits (mirrors the gRPC backend, which cannot
+    # enforce them until the vendor RPC is mapped) - the runner must trip.
+    sim = RigSimulator(params=MotorParams(), noise=0.0)
+    stand = SimulatedStand(sim, fixed_dt=0.01).open()
+    sources = Sources(
+        throttle=FlightStandThrottle(stand, arm_settle_s=0.0),
+        stand=stand,
+        perf_source=lambda: None,
+        telem_source=lambda: None,
+    )
+    result = run_profile(_profile(max_current_a=5.0), sources, realtime=False)
+    assert result.meta["aborted"] is not None
+    assert "safety" in result.meta["aborted"]
+    assert "current" in result.meta["aborted"]
+
+
+def test_runner_trips_on_telemetry_only_rig():
+    # No stand at all: the ESC telemetry current must still enforce the limit.
+    class _DummyThrottle:
+        def arm(self): pass
+        def set(self, throttle): pass
+        def disarm(self): pass
+        def close(self): pass
+
+    sources = Sources(
+        throttle=_DummyThrottle(),
+        stand=None,
+        perf_source=lambda: None,
+        telem_source=lambda: _frame(current_a=60.0),
+    )
+    result = run_profile(_profile(max_current_a=45.0), sources, realtime=False)
+    assert result.meta["aborted"] is not None
+    assert "current" in result.meta["aborted"]
+
+
+def test_standless_run_completes_within_limits():
+    class _DummyThrottle:
+        def arm(self): pass
+        def set(self, throttle): pass
+        def disarm(self): pass
+        def close(self): pass
+
+    sources = Sources(
+        throttle=_DummyThrottle(),
+        stand=None,
+        perf_source=lambda: None,
+        telem_source=lambda: _frame(current_a=10.0),
+    )
+    result = run_profile(_profile(max_current_a=45.0), sources, realtime=False)
+    assert result.meta["aborted"] is None
+    assert len(result.rows) == 200
+    assert result.rows[0]["stand_thrust_gf"] == ""  # stand columns empty

--- a/hwci/tests/test_runner_sim.py
+++ b/hwci/tests/test_runner_sim.py
@@ -1,0 +1,56 @@
+"""End-to-end simulated runs through the runner + metrics + persistence."""
+from hwci import metrics as metricsmod
+from hwci.config import RigConfig, load_profile
+from hwci.model import RunResult
+from hwci.runner import build_sim_sources, run_profile
+
+
+def _run(profile_name, demag_prone=True):
+    rig = RigConfig()
+    profile = load_profile(profile_name)
+    sources = build_sim_sources(rig, profile, demag_prone=demag_prone)
+    try:
+        return run_profile(profile, sources, realtime=False,
+                           meta={"target": "ARK_4IN1_F051"}), profile
+    finally:
+        sources.close()
+
+
+def test_ci_smoke_runs_and_has_steady_points():
+    result, profile = _run("ci_smoke")
+    assert result.meta["aborted"] is None
+    assert len(result.rows) > 100
+    m = metricsmod.compute(result, profile)
+    assert len(m["steady_points"]) == 2          # hold25, hold45
+    assert m["summary"]["max_thrust_gf"] > 0
+    assert m["summary"]["peak_efficiency_gf_per_w"] > 0
+    assert 0 <= m["summary"]["max_cpu_load_pct"] <= 100
+    # Smooth ramps must not be flagged as demag.
+    assert m["summary"]["demag_events"] == 0
+
+
+def test_efficiency_sweep_curve_is_monotonic_thrust():
+    result, profile = _run("efficiency_sweep")
+    m = metricsmod.compute(result, profile)
+    thrusts = [p["thrust_gf"] for p in m["steady_points"]]
+    assert thrusts == sorted(thrusts)            # thrust rises with throttle
+    assert len(m["steady_points"]) == 10
+
+
+def test_demag_profile_detects_events():
+    result, profile = _run("demag_step_stress", demag_prone=True)
+    m = metricsmod.compute(result, profile)
+    assert m["summary"]["demag_events"] >= 1
+    assert m["demag"]["bemf_timeout_samples"] >= 1
+
+
+def test_save_load_roundtrip(tmp_path):
+    result, profile = _run("ci_smoke")
+    result.save(tmp_path / "run")
+    loaded = RunResult.load(tmp_path / "run")
+    assert len(loaded.rows) == len(result.rows)
+    assert loaded.meta["profile"] == "ci_smoke"
+    # metrics identical after roundtrip
+    m1 = metricsmod.compute(result, profile)
+    m2 = metricsmod.compute(loaded, profile)
+    assert m1["summary"]["max_thrust_gf"] == m2["summary"]["max_thrust_gf"]

--- a/hwci/tests/test_sim.py
+++ b/hwci/tests/test_sim.py
@@ -1,0 +1,65 @@
+"""Tests for the rig simulator: cross-channel consistency + demag injection."""
+import pytest
+
+from hwci import perf
+from hwci.esc_telem import parse_frame
+from hwci.sim import MotorParams, RigSimulator
+
+
+def _settle(rig, throttle, n=200, dt=0.005):
+    for _ in range(n):
+        rig.step(dt, throttle)
+
+
+def test_thrust_increases_with_throttle():
+    lo = RigSimulator(noise=0.0)
+    hi = RigSimulator(noise=0.0)
+    _settle(lo, 0.3)
+    _settle(hi, 0.8)
+    assert hi.thrust_n > lo.thrust_n > 0
+
+
+def test_efficiency_is_plausible():
+    rig = RigSimulator(noise=0.0)
+    _settle(rig, 0.5)
+    s = rig.stand_sample(1.0)
+    # A few g/W is realistic for a loaded 5" setup.
+    assert 1.0 < s.efficiency_gf_per_w < 15.0
+
+
+def test_kiss_channel_matches_state():
+    rig = RigSimulator(noise=0.0)
+    _settle(rig, 0.6)
+    frame = parse_frame(rig.kiss_bytes())
+    assert frame.crc_ok
+    assert frame.voltage_v == pytest.approx(rig.voltage, abs=0.05)
+    assert frame.e_rpm == pytest.approx(rig.e_rpm, rel=0.02, abs=200)
+
+
+def test_perf_channel_decodes_and_is_consistent():
+    rig = RigSimulator(noise=0.0)
+    _settle(rig, 0.7)
+    sample = perf.decode(rig.perf_bytes())
+    assert sample.raw["running"] == 1
+    assert 0 < sample.raw["commutation_interval_max"]
+    assert sample.loop_iters > 0
+    assert sample.e_rpm == pytest.approx(rig.e_rpm, rel=0.02, abs=200)
+
+
+def test_demag_injection_triggers_desync():
+    rig = RigSimulator(params=MotorParams(demag_prone=True), noise=0.0)
+    _settle(rig, 0.1, n=50)
+    rpm_before = rig.rpm
+    rig.step(0.005, 1.0)   # violent step into a high-current regime
+    assert rig.desync_count >= 1
+    # Sync loss collapses RPM rather than spooling up.
+    assert rig.rpm < rpm_before * 1.1
+    sample = perf.decode(rig.perf_bytes())
+    assert sample.raw["bemf_timeout_state"] == 1
+
+
+def test_no_demag_when_not_prone():
+    rig = RigSimulator(params=MotorParams(demag_prone=False), noise=0.0)
+    _settle(rig, 0.1, n=50)
+    rig.step(0.005, 1.0)
+    assert rig.desync_count == 0

--- a/hwci/tests/test_tail_reset_margin.py
+++ b/hwci/tests/test_tail_reset_margin.py
@@ -1,0 +1,33 @@
+"""_tail_reset_tick: the mid-segment perf-stats reset must land strictly
+before the metrics tail window, not at its boundary.
+
+reset_stats() clears the firmware register over an SWD round trip, and in
+realtime mode perf_get() reads an independent background poller's CACHED
+value (~2ms interval) - so the tick that ISSUES the reset can still observe
+the pre-reset cached sample. Observed on the bench: an 877us arming-tune
+transient latched at a segment's first tick was still visible in the exact
+sample the reset was issued on, making the "steady" max equal the raw run
+max. The fix needs a margin, not an exact boundary match - and that margin
+must be measured against the SAME tail_start_index() metrics.py uses: an
+earlier version of this fix recomputed the tail boundary with its own
+independently-rounded formula (round() vs metrics.py's int() truncation),
+which silently disagreed by a tick for some segment lengths (e.g. n=300,
+fraction=0.8) - exactly the kind of gap this race hides in.
+"""
+from hwci.metrics import tail_start_index
+from hwci.runner import RESET_MARGIN_TICKS, _tail_reset_tick
+
+
+def test_reset_lands_before_metrics_tail_with_margin():
+    for n, fraction in [(1000, 0.5), (600, 0.5), (100, 0.3), (300, 0.8)]:
+        reset_tick = _tail_reset_tick(n, fraction)
+        tail_start = tail_start_index(n, fraction)
+        assert reset_tick <= tail_start - RESET_MARGIN_TICKS, (
+            f"n={n} fraction={fraction}: reset_tick={reset_tick} leaves "
+            f"less than {RESET_MARGIN_TICKS}-tick margin before tail_start={tail_start}")
+
+
+def test_reset_tick_never_negative_on_short_segments():
+    # A segment shorter than the margin must clamp to 0, not go negative.
+    assert _tail_reset_tick(5, 0.5) == 0
+    assert _tail_reset_tick(1, 0.9) == 0

--- a/hwci/tests/test_tare.py
+++ b/hwci/tests/test_tare.py
@@ -1,0 +1,55 @@
+"""Pre-run tare: zero the load cells only AFTER the ESC signal is up at zero
+throttle. AM32 beeps the motor whenever it has NO input signal (and again as
+it arms), and each beep is a torque pulse through the mount - a tare taken on
+a beeping ESC bakes that twitching into the load-cell zero (seen on the bench
+as a wandering thrust offset between runs)."""
+from types import SimpleNamespace
+
+from hwci.runner import ARM_TUNE_SETTLE_S, TARE_SETTLE_S, tare_for_run
+
+
+class _Rig:
+    """Fake stand + throttle sharing ONE event log, so tests can assert
+    ordering ACROSS the two objects - the whole point of the choreography."""
+
+    def __init__(self, thrust_n=0.0, read_raises=False):
+        self.events: list = []
+        self._thrust_n = thrust_n
+        self._read_raises = read_raises
+        self.throttle = SimpleNamespace(arm=lambda: self.events.append("arm"))
+        self.stand = SimpleNamespace(tare=lambda: self.events.append("tare"),
+                                     read_sample=self._read_sample)
+
+    def _read_sample(self):
+        self.events.append("read")
+        if self._read_raises:
+            raise RuntimeError("stand went away")
+        return SimpleNamespace(thrust_n=self._thrust_n)
+
+    def settle(self, seconds: float) -> None:
+        self.events.append(("settle", seconds))
+
+
+def test_signal_is_up_and_arm_tune_finished_before_tare():
+    rig = _Rig()
+    tare_for_run(rig.stand, rig.throttle, settle=rig.settle)
+    assert rig.events == [
+        "arm",                          # signal at zero: beacon stops
+        ("settle", ARM_TUNE_SETTLE_S),  # arm tune stops shaking the motor
+        "tare",
+        ("settle", TARE_SETTLE_S),      # post-tare readings settle
+        "read",
+    ]
+
+
+def test_residual_is_reported_in_gf():
+    rig = _Rig(thrust_n=0.0980665)  # exactly 10 gf
+    residual = tare_for_run(rig.stand, rig.throttle, settle=rig.settle)
+    assert abs(residual - 10.0) < 1e-9
+
+
+def test_residual_read_is_best_effort_but_tare_is_not():
+    rig = _Rig(read_raises=True)
+    residual = tare_for_run(rig.stand, rig.throttle, settle=rig.settle)
+    assert residual is None          # unreadable residual doesn't kill the run
+    assert "tare" in rig.events      # ... but the tare itself already happened

--- a/hwci/tests/test_throttle_map.py
+++ b/hwci/tests/test_throttle_map.py
@@ -1,0 +1,58 @@
+"""DShot throttle mapping: zero throttle must be DShot 0, never 1-47.
+
+AM32 only arms on sustained DShot 0 (verified on the ARK 4IN1 bench: at a
+constant DShot 48 the ESC decodes input=48 but never arms, Src/main.c requires
+adjusted_input == 0 for one second). Values 1-47 are DShot COMMANDS - a ramp
+must never sweep through them.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hwci.flightstand.grpc_client import FlightStandGrpc, SignalMap
+
+
+class RecordingApi:
+    def __init__(self):
+        self.calls = []
+
+    def set_output(self, output_id, value, *, active=True):
+        self.calls.append((output_id, value, active))
+
+
+def make_stand(**signal_overrides) -> tuple[FlightStandGrpc, RecordingApi]:
+    stand = FlightStandGrpc(signals=SignalMap(**signal_overrides))
+    stand._api = RecordingApi()
+    return stand, stand._api
+
+
+def test_dshot_zero_throttle_is_dshot_zero():
+    stand, api = make_stand(esc_zero=0.0, esc_min=48.0, esc_max=2047.0)
+    stand.set_throttle(0.0)
+    assert api.calls[-1] == (0, 0.0, True)
+
+
+def test_dshot_positive_throttle_starts_at_48_never_commands():
+    stand, api = make_stand(esc_zero=0.0, esc_min=48.0, esc_max=2047.0)
+    for t in (1e-6, 0.001, 0.01, 0.10, 1.0):
+        stand.set_throttle(t)
+        raw = api.calls[-1][1]
+        assert raw >= 48.0, f"throttle {t} emitted DShot command value {raw}"
+    stand.set_throttle(1.0)
+    assert api.calls[-1][1] == pytest.approx(2047.0)
+
+
+def test_pwm_default_zero_is_esc_min():
+    # esc_zero=None: standard PWM where 1000 us is both zero and idle
+    stand, api = make_stand(esc_min=1000.0, esc_max=2000.0)
+    stand.set_throttle(0.0)
+    assert api.calls[-1][1] == pytest.approx(1000.0)
+    stand.set_throttle(0.5)
+    assert api.calls[-1][1] == pytest.approx(1500.0)
+
+
+def test_close_parks_at_esc_zero_then_deactivates():
+    stand, api = make_stand(esc_zero=0.0, esc_min=48.0, esc_max=2047.0)
+    stand.close()
+    assert api.calls[-2] == (0, 0.0, True)
+    assert api.calls[-1] == (0, 0.0, False)


### PR DESCRIPTION
Baseline branch for hardware-in-the-loop testing: unmodified am32-firmware/AM32 main plus only the ARK hwci test harness (hwci/, hwci_perf opt-in instrumentation, and the .github hwci workflow). Excludes all ARK-specific performance and correctness changes (Q16 duty-cycle/setInput math, F051 RAM-function placement, F051 SysTick-no-IRQ, ISR-shared volatile fixes, MCU extern-decl fixes) so this can serve as a stock-firmware baseline to compare against.